### PR TITLE
feat: Check for updates WIP

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,7 +18,7 @@ A clear and concise description of what the bug is.
 
 **Debug logs if an error occurred**
 
-Outlined here: https://github.com/fuatakgun/kia_uvo/blob/master/README.m
+Outlined here: https://github.com/fuatakgun/kia_uvo/blob/master/README.md
 
 
 **To Reproduce**

--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         stages: [manual]
         args:
           - --quiet-level=2
-          - --ignore-words-list=hass,ba,fo,ist,Deine,Adresse
+          - --ignore-words-list="hass,ba,fo,ist,Deine,Adresse"
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0

--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         stages: [manual]
         args:
           - --quiet-level=2
-          - --ignore-words-list=hass,ba,fo
+          - --ignore-words-list=hass,ba,fo,ist,Deine,Adresse
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0

--- a/.github/pre-commit-config.yaml
+++ b/.github/pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         stages: [manual]
         args:
           - --quiet-level=2
-          - --ignore-words-list="hass,ba,fo,ist,Deine,Adresse"
+          - -L=hass,ba,fo,ist,deine,adresse
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,14 +8,14 @@ jobs:
   validate-hassfest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Hassfest validation
         uses: home-assistant/actions/hassfest@master
 
   validate-hacs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: HACS validation
         uses: hacs/action@main
         with:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ You can install this either manually copying files or using HACS. Configuration 
 - cache update interval, force update interval, blackout start and finish hours
 
 ## Supported services ##
+These can be access by going to the developer menu followed by services. 
+
 - update: get latest **cached** vehicle data
 - force_update: this will make a call to your vehicle to get its latest data, do not overuse this!
 - start_climate / stop_climate: Starts the ICE engine in some regions or starts EV climate. 
@@ -44,7 +46,7 @@ You can install this either manually copying files or using HACS. Configuration 
 | start stop climate | &#10004;  | &#10004;  | &#10004;       | &#10004;           |
 | start stop charge  | &#10004;  | &#10004;  | &#10004;       |            |
 | set charge limits  | &#10004;  | &#10004;  | &#10004;       |            |
-| open and close charge port  | &#10004;  |   | |          |
+| open and close charge port(None functional, needs testing)  | &#10004;  |   | |          |
 
 I have posted an example screenshot from my own car.
 

--- a/custom_components/kia_uvo/binary_sensor.py
+++ b/custom_components/kia_uvo/binary_sensor.py
@@ -207,6 +207,20 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         off_icon="mdi:ev-station",
         device_class=BinarySensorDeviceClass.DOOR,
     ),
+    HyundaiKiaBinarySensorEntityDescription(
+        key="ev_first_departure_enabled",
+        name="EV First Scheduled Departure",
+        is_on=lambda vehicle: vehicle.ev_first_departure_enabled,
+        on_icon="mdi:clock-outline",
+        off_icon="mdi:clock-outline",
+    ),
+    HyundaiKiaBinarySensorEntityDescription(
+        key="ev_second_departure_enabled",
+        name="EV First Scheduled Departure",
+        is_on=lambda vehicle: vehicle.ev_second_departure_enabled,
+        on_icon="mdi:clock-outline",
+        off_icon="mdi:clock-outline",
+    ),
 )
 
 

--- a/custom_components/kia_uvo/binary_sensor.py
+++ b/custom_components/kia_uvo/binary_sensor.py
@@ -216,7 +216,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="ev_second_departure_enabled",
-        name="EV First Scheduled Departure",
+        name="EV Second Scheduled Departure",
         is_on=lambda vehicle: vehicle.ev_second_departure_enabled,
         on_icon="mdi:clock-outline",
         off_icon="mdi:clock-outline",

--- a/custom_components/kia_uvo/config_flow.py
+++ b/custom_components/kia_uvo/config_flow.py
@@ -134,6 +134,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Hyundai / Kia Connect."""
 
     VERSION = 2
+    reauth_entry: ConfigEntry | None = None
 
     @staticmethod
     @callback
@@ -171,6 +172,23 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
         )
+
+    async def async_step_reauth(self, user_input=None):
+        """Perform reauth upon an API authentication error."""
+        self.reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input=None):
+        """Dialog that informs the user that reauth is required."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="reauth_confirm",
+                data_schema=vol.Schema({}),
+            )
+        self._reauth = True
+        return await self.async_step_user()
 
 
 class InvalidAuth(HomeAssistantError):

--- a/custom_components/kia_uvo/config_flow.py
+++ b/custom_components/kia_uvo/config_flow.py
@@ -58,6 +58,7 @@ async def validate_input(hass: HomeAssistant, user_input: dict[str, Any]) -> Tok
     api = VehicleManager.get_implementation_by_region_brand(
         user_input[CONF_REGION],
         user_input[CONF_BRAND],
+        language=hass.config.language,
     )
     token: Token = await hass.async_add_executor_job(
         api.login, user_input[CONF_USERNAME], user_input[CONF_PASSWORD]

--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -179,65 +179,61 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def async_lock_vehicle(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        action_id = await self.hass.async_add_executor_job(
-            self.vehicle_manager.lock, vehicle_id
-        )
-        await self.async_wait_for_action_completed(vehicle_id, action_id)
+        await self.hass.async_add_executor_job(self.vehicle_manager.lock, vehicle_id)
+        await self.async_wait_for_action_completed(vehicle_id)
 
     async def async_unlock_vehicle(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        action_id = await self.hass.async_add_executor_job(
-            self.vehicle_manager.unlock, vehicle_id
-        )
-        await self.async_wait_for_action_completed(vehicle_id, action_id)
+        await self.hass.async_add_executor_job(self.vehicle_manager.unlock, vehicle_id)
+        await self.async_wait_for_action_completed(vehicle_id)
 
     async def async_open_charge_port(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        action_id = await self.hass.async_add_executor_job(
+        await self.hass.async_add_executor_job(
             self.vehicle_manager.open_charge_port, vehicle_id
         )
-        await self.async_wait_for_action_completed(vehicle_id, action_id)
+        await self.async_wait_for_action_completed(vehicle_id)
 
     async def async_close_charge_port(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        action_id = await self.hass.async_add_executor_job(
+        await self.hass.async_add_executor_job(
             self.vehicle_manager.close_charge_port, vehicle_id
         )
-        await self.async_wait_for_action_completed(vehicle_id, action_id)
+        await self.async_wait_for_action_completed(vehicle_id)
 
     async def async_start_climate(
         self, vehicle_id: str, climate_options: ClimateRequestOptions
     ):
         await self.async_check_and_refresh_token()
-        action_id = await self.hass.async_add_executor_job(
+        await self.hass.async_add_executor_job(
             self.vehicle_manager.start_climate, vehicle_id, climate_options
         )
-        await self.async_wait_for_action_completed(vehicle_id, action_id)
+        await self.async_wait_for_action_completed(vehicle_id)
 
     async def async_stop_climate(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        action_id = await self.hass.async_add_executor_job(
+        await self.hass.async_add_executor_job(
             self.vehicle_manager.stop_climate, vehicle_id
         )
-        await self.async_wait_for_action_completed(vehicle_id, action_id)
+        await self.async_wait_for_action_completed(vehicle_id)
 
     async def async_start_charge(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        action_id = await self.hass.async_add_executor_job(
+        await self.hass.async_add_executor_job(
             self.vehicle_manager.start_charge, vehicle_id
         )
-        await self.async_wait_for_action_completed(vehicle_id, action_id)
+        await self.async_wait_for_action_completed(vehicle_id)
 
     async def async_stop_charge(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        action_id = await self.hass.async_add_executor_job(
+        await self.hass.async_add_executor_job(
             self.vehicle_manager.stop_charge, vehicle_id
         )
-        await self.async_wait_for_action_completed(vehicle_id, action_id)
+        await self.async_wait_for_action_completed(vehicle_id)
 
     async def set_charge_limits(self, vehicle_id: str, ac: int, dc: int):
         await self.async_check_and_refresh_token()
-        action_id = await self.hass.async_add_executor_job(
+        await self.hass.async_add_executor_job(
             self.vehicle_manager.set_charge_limits, vehicle_id, ac, dc
         )
-        await self.async_wait_for_action_completed(vehicle_id, action_id)
+        await self.async_wait_for_action_completed(vehicle_id)

--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -161,9 +161,9 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
         )
 
     async def async_wait_for_action_completed(
-        self, vehicle_id: int, action_id: str, interval:int=5, max_count:int=6
+        self, vehicle_id: int, action_id: str, interval: int = 5, max_count: int = 6
     ):
-        for count in range(1, max_count+1):
+        for count in range(1, max_count + 1):
             _LOGGER.debug(f"Last action check: waiting {interval} seconds")
             await asyncio.sleep(interval)
             _LOGGER.debug(f"Last action check: attempt {count} of {max_count}")
@@ -178,12 +178,16 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def async_lock_vehicle(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        action_id = await self.hass.async_add_executor_job(self.vehicle_manager.lock, vehicle_id)
+        action_id = await self.hass.async_add_executor_job(
+            self.vehicle_manager.lock, vehicle_id
+        )
         await self.async_wait_for_action_completed(vehicle_id, action_id)
 
     async def async_unlock_vehicle(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        action_id = await self.hass.async_add_executor_job(self.vehicle_manager.unlock, vehicle_id)
+        action_id = await self.hass.async_add_executor_job(
+            self.vehicle_manager.unlock, vehicle_id
+        )
         await self.async_wait_for_action_completed(vehicle_id, action_id)
 
     async def async_open_charge_port(self, vehicle_id: str):

--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -61,6 +61,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
             geocode_api_use_email=config_entry.options.get(
                 CONF_USE_EMAIL_WITH_GEOCODE_API, DEFAULT_USE_EMAIL_WITH_GEOCODE_API
             ),
+            language=hass.config.language,
         )
         self.scan_interval: int = (
             config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL) * 60

--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -127,7 +127,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
                         self.vehicle_manager.update_all_vehicles_with_cached_state
                     )
                     _LOGGER.exception(
-                        "Force update failed, falling back to cached: {err}"
+                        f"Force update failed, falling back to cached: {err}"
                     )
                 except Exception as err_nested:
                     raise UpdateFailed(f"Error communicating with API: {err_nested}")

--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 
 import logging
 from site import venv
+import asyncio
 
 from hyundai_kia_connect_api import (
     VehicleManager,
@@ -159,63 +160,79 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
             self.vehicle_manager.check_and_refresh_token
         )
 
+    async def async_wait_for_action_completed(
+        self, vehicle_id: int, action_id: str, interval:int=5, max_count:int=6
+    ):
+        for count in range(1, max_count+1):
+            _LOGGER.debug(f"Last action check: waiting {interval} seconds")
+            await asyncio.sleep(interval)
+            _LOGGER.debug(f"Last action check: attempt {count} of {max_count}")
+            is_completed = await self.hass.async_add_executor_job(
+                self.vehicle_manager.check_action_status, vehicle_id, action_id
+            )
+            _LOGGER.debug(f"Last action completed: {is_completed}")
+            if is_completed:
+                await self.async_refresh()
+                break
+        return is_completed
+
     async def async_lock_vehicle(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(self.vehicle_manager.lock, vehicle_id)
-        await self.async_request_refresh()
+        action_id = await self.hass.async_add_executor_job(self.vehicle_manager.lock, vehicle_id)
+        await self.async_wait_for_action_completed(vehicle_id, action_id)
 
     async def async_unlock_vehicle(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(self.vehicle_manager.unlock, vehicle_id)
-        await self.async_request_refresh()
+        action_id = await self.hass.async_add_executor_job(self.vehicle_manager.unlock, vehicle_id)
+        await self.async_wait_for_action_completed(vehicle_id, action_id)
 
     async def async_open_charge_port(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
+        action_id = await self.hass.async_add_executor_job(
             self.vehicle_manager.open_charge_port, vehicle_id
         )
-        await self.async_request_refresh()
+        await self.async_wait_for_action_completed(vehicle_id, action_id)
 
     async def async_close_charge_port(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
+        action_id = await self.hass.async_add_executor_job(
             self.vehicle_manager.close_charge_port, vehicle_id
         )
-        await self.async_request_refresh()
+        await self.async_wait_for_action_completed(vehicle_id, action_id)
 
     async def async_start_climate(
         self, vehicle_id: str, climate_options: ClimateRequestOptions
     ):
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
+        action_id = await self.hass.async_add_executor_job(
             self.vehicle_manager.start_climate, vehicle_id, climate_options
         )
-        await self.async_request_refresh()
+        await self.async_wait_for_action_completed(vehicle_id, action_id)
 
     async def async_stop_climate(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
+        action_id = await self.hass.async_add_executor_job(
             self.vehicle_manager.stop_climate, vehicle_id
         )
-        await self.async_request_refresh()
+        await self.async_wait_for_action_completed(vehicle_id, action_id)
 
     async def async_start_charge(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
+        action_id = await self.hass.async_add_executor_job(
             self.vehicle_manager.start_charge, vehicle_id
         )
-        await self.async_request_refresh()
+        await self.async_wait_for_action_completed(vehicle_id, action_id)
 
     async def async_stop_charge(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
+        action_id = await self.hass.async_add_executor_job(
             self.vehicle_manager.stop_charge, vehicle_id
         )
-        await self.async_request_refresh()
+        await self.async_wait_for_action_completed(vehicle_id, action_id)
 
     async def set_charge_limits(self, vehicle_id: str, ac: int, dc: int):
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
+        action_id = await self.hass.async_add_executor_job(
             self.vehicle_manager.set_charge_limits, vehicle_id, ac, dc
         )
-        await self.async_request_refresh()
+        await self.async_wait_for_action_completed(vehicle_id, action_id)

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://github.com/fuatakgun/kia_uvo",
   "issue_tracker": "https://github.com/fuatakgun/kia_uvo/issues",
   "codeowners": ["@fuatakgun"],
-  "requirements": ["hyundai_kia_connect_api==1.47.1"],
+  "requirements": ["hyundai_kia_connect_api==1.47.2"],
   "version": "2.0.50",
   "config_flow": true,
   "iot_class": "cloud_polling",

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://github.com/fuatakgun/kia_uvo",
   "issue_tracker": "https://github.com/fuatakgun/kia_uvo/issues",
   "codeowners": ["@fuatakgun"],
-  "requirements": ["hyundai_kia_connect_api==1.52.2"],
+  "requirements": ["hyundai_kia_connect_api==1.52.3"],
   "version": "2.2.1",
   "config_flow": true,
   "iot_class": "cloud_polling",

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -5,7 +5,7 @@
   "issue_tracker": "https://github.com/fuatakgun/kia_uvo/issues",
   "codeowners": ["@fuatakgun"],
   "requirements": ["hyundai_kia_connect_api==1.52.4"],
-  "version": "2.2.1",
+  "version": "2.3.0",
   "config_flow": true,
   "iot_class": "cloud_polling",
   "integration_type": "hub"

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -5,7 +5,7 @@
   "issue_tracker": "https://github.com/fuatakgun/kia_uvo/issues",
   "codeowners": ["@fuatakgun"],
   "requirements": ["hyundai_kia_connect_api==1.47.2"],
-  "version": "2.0.50",
+  "version": "2.1.0",
   "config_flow": true,
   "iot_class": "cloud_polling",
   "integration_type": "hub"

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://github.com/fuatakgun/kia_uvo",
   "issue_tracker": "https://github.com/fuatakgun/kia_uvo/issues",
   "codeowners": ["@fuatakgun"],
-  "requirements": ["hyundai_kia_connect_api==1.52.0"],
+  "requirements": ["hyundai_kia_connect_api==1.52.2"],
   "version": "2.2.1",
   "config_flow": true,
   "iot_class": "cloud_polling",

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -5,7 +5,7 @@
   "issue_tracker": "https://github.com/fuatakgun/kia_uvo/issues",
   "codeowners": ["@fuatakgun"],
   "requirements": ["hyundai_kia_connect_api==1.50.3"],
-  "version": "2.2.0",
+  "version": "2.2.1",
   "config_flow": true,
   "iot_class": "cloud_polling",
   "integration_type": "hub"

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://github.com/fuatakgun/kia_uvo",
   "issue_tracker": "https://github.com/fuatakgun/kia_uvo/issues",
   "codeowners": ["@fuatakgun"],
-  "requirements": ["hyundai_kia_connect_api==1.50.3"],
+  "requirements": ["hyundai_kia_connect_api==1.51.0"],
   "version": "2.2.1",
   "config_flow": true,
   "iot_class": "cloud_polling",

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://github.com/fuatakgun/kia_uvo",
   "issue_tracker": "https://github.com/fuatakgun/kia_uvo/issues",
   "codeowners": ["@fuatakgun"],
-  "requirements": ["hyundai_kia_connect_api==1.47.3"],
+  "requirements": ["hyundai_kia_connect_api==1.49.0"],
   "version": "2.1.0",
   "config_flow": true,
   "iot_class": "cloud_polling",

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://github.com/fuatakgun/kia_uvo",
   "issue_tracker": "https://github.com/fuatakgun/kia_uvo/issues",
   "codeowners": ["@fuatakgun"],
-  "requirements": ["hyundai_kia_connect_api==1.51.1"],
+  "requirements": ["hyundai_kia_connect_api==1.52.0"],
   "version": "2.2.1",
   "config_flow": true,
   "iot_class": "cloud_polling",

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://github.com/fuatakgun/kia_uvo",
   "issue_tracker": "https://github.com/fuatakgun/kia_uvo/issues",
   "codeowners": ["@fuatakgun"],
-  "requirements": ["hyundai_kia_connect_api==1.52.3"],
+  "requirements": ["hyundai_kia_connect_api==1.52.4"],
   "version": "2.2.1",
   "config_flow": true,
   "iot_class": "cloud_polling",

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://github.com/fuatakgun/kia_uvo",
   "issue_tracker": "https://github.com/fuatakgun/kia_uvo/issues",
   "codeowners": ["@fuatakgun"],
-  "requirements": ["hyundai_kia_connect_api==1.49.0"],
+  "requirements": ["hyundai_kia_connect_api==1.50.3"],
   "version": "2.1.0",
   "config_flow": true,
   "iot_class": "cloud_polling",

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://github.com/fuatakgun/kia_uvo",
   "issue_tracker": "https://github.com/fuatakgun/kia_uvo/issues",
   "codeowners": ["@fuatakgun"],
-  "requirements": ["hyundai_kia_connect_api==1.47.2"],
+  "requirements": ["hyundai_kia_connect_api==1.47.3"],
   "version": "2.1.0",
   "config_flow": true,
   "iot_class": "cloud_polling",

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://github.com/fuatakgun/kia_uvo",
   "issue_tracker": "https://github.com/fuatakgun/kia_uvo/issues",
   "codeowners": ["@fuatakgun"],
-  "requirements": ["hyundai_kia_connect_api==1.51.0"],
+  "requirements": ["hyundai_kia_connect_api==1.51.1"],
   "version": "2.2.1",
   "config_flow": true,
   "iot_class": "cloud_polling",

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://github.com/fuatakgun/kia_uvo",
   "issue_tracker": "https://github.com/fuatakgun/kia_uvo/issues",
   "codeowners": ["@fuatakgun"],
-  "requirements": ["hyundai_kia_connect_api==1.52.4"],
+  "requirements": ["hyundai_kia_connect_api==1.52.5"],
   "version": "2.3.0",
   "config_flow": true,
   "iot_class": "cloud_polling",

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -5,7 +5,7 @@
   "issue_tracker": "https://github.com/fuatakgun/kia_uvo/issues",
   "codeowners": ["@fuatakgun"],
   "requirements": ["hyundai_kia_connect_api==1.50.3"],
-  "version": "2.1.0",
+  "version": "2.2.0",
   "config_flow": true,
   "iot_class": "cloud_polling",
   "integration_type": "hub"

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -185,6 +185,11 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         name="Geocoded Location",
         icon="mdi:map",
     ),
+    SensorEntityDescription(
+        key="dtc_count",
+        name="DTC Count",
+        icon="mdi:alert-circle",
+    ),
 )
 
 
@@ -244,6 +249,8 @@ class HyundaiKiaConnectSensor(SensorEntity, HyundaiKiaConnectEntity):
     def state_attributes(self):
         if self._description.key == "_geocode_name":
             return {"address": getattr(self.vehicle, "_geocode_address")}
+        elif self._description.key == "dtc_count":
+            return {"DTC Text": getattr(self.vehicle, "dtc_descriptions")}
 
 
 class VehicleEntity(SensorEntity, HyundaiKiaConnectEntity):

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -190,6 +190,26 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         name="DTC Count",
         icon="mdi:alert-circle",
     ),
+    SensorEntityDescription(
+        key="ev_first_departure_time",
+        name="EV First Scheduled Depature Time",
+        icon="mdi:clock-outline",
+    ),
+    SensorEntityDescription(
+        key="ev_second_departure_time",
+        name="EV Second Scheduled Depature Time",
+        icon="mdi:clock-outline",
+    ),
+    SensorEntityDescription(
+        key="ev_off_peak_start_time",
+        name="EV Off Peak Start Time",
+        icon="mdi:clock-outline",
+    ),
+    SensorEntityDescription(
+        key="ev_off_peak_end_time",
+        name="EV Off Peak End Time",
+        icon="mdi:clock-outline",
+    ),
 )
 
 

--- a/custom_components/kia_uvo/strings.json
+++ b/custom_components/kia_uvo/strings.json
@@ -9,6 +9,10 @@
           "brand": "[%key:component::hyundai_kia_connect::config::step::user::data::brand%]",
           "pin": "[%key:common::config_flow::data::pin%]"
         }
+      },
+      "reauth_confirm": {
+        "title": "[%key:common::config_flow::title::reauth%]",
+        "description": "The Hyundai / Kia Connect integration needs to re-authenticate your account"
       }
     },
     "error": {
@@ -16,7 +20,8 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
   "options": {

--- a/custom_components/kia_uvo/translations/de.json
+++ b/custom_components/kia_uvo/translations/de.json
@@ -1,0 +1,40 @@
+{
+    "title": "Hyundai / Kia Connect",
+    "config": {
+        "step": {
+            "user": {
+                "title": "Hyundai / Kia Connect: Anmelden",
+                "description": "Hyundai Bluelink / Kia Uvo Connect Login für Home Assistant.",
+                "data": {
+                    "username": "Benutzername",
+                    "password": "Passwort",
+                    "region": "Region",
+                    "brand": "Marke",
+                    "pin": "PIN (notwendig für CA)"
+                }
+            }
+        },
+        "abort": {
+            "already_configured": "Dein Fahrzeug ist bereits konfiguriert"
+        },
+        "error": {
+            "invalid_auth": "Login für Hyundai (Bluelink) / Kia (Uvo) Connect fehlgeschlagen. Bitte melde Dich in Deiner Hyundai/Kia-App ab, logge Dich dort neu ein und versuche es erneut!",
+            "unknown": "Unbekannter Fehler"
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Hyundai / Kia Connect: Konfiguration",
+                "data": {
+                    "scan_interval": "Scan-Intervall (Min.)",
+                    "force_refresh": "Force-Refresh-Intervall (Min.)",
+                    "no_force_refresh_hour_start": "Force Refresh anhalten ab",
+                    "no_force_refresh_hour_finish": "Force Refresh zulassen ab",
+                    "enable_geolocation_entity": "Geolocation Entität über OpenStreetMap aktivieren",
+                    "use_email_with_geocode_api": "Verwende Deine Kia E-Mail Adresse für die Geocode API - für weitere Informationen: https://nominatim.org/release-docs/develop/api/Reverse/#other"
+                }
+            }
+        }
+    }
+}

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "Kia Uvo / Hyundai Bluelink",
   "render_readme": true,
-  "homeassistant": "2022.10",
+  "homeassistant": "2022.12",
   "content_in_root": false
 }


### PR DESCRIPTION
Proposal for tracking API status updates, solution for issue #440. Also see pull request in the hyundai_kia_connect_api repo with required changes to the API. Work in progress, thankful for any input. The code works for me (CA/Hyundai)

**Changes in kia_uvo**
* all vehicle commands call async_wait_for_action_completed after the action has beeen sent (rather than async_request_refresh which just receives stale data)
* async_wait_for_action_completed calls vm.check_action_status every X seconds a maximum of Y times
* when vm.check_action_status responds True, async_refresh() is called to refresh values in HA

**Changes in hyundai_kia_connect_api**
* CA.check_last_action_status updates vehicle properties if action completed successfully
* Token gets parameter last_action_pin_token required for CA.check_last_action_status
* EU gets a mock check_last_action_status for compatibility