### PR TITLE
fix:  No Longer Require ID for Update

### DIFF
--- a/custom_components/kia_uvo/services.py
+++ b/custom_components/kia_uvo/services.py
@@ -149,9 +149,9 @@ def _get_vehicle_id_from_device(hass: HomeAssistant, call: ServiceCall) -> str:
 def _get_coordinator_from_device(
     hass: HomeAssistant, call: ServiceCall
 ) -> HyundaiKiaConnectDataUpdateCoordinator:
-    vehicle_identifiers = list(hass.data[DOMAIN].keys())
-    if len(vehicle_identifiers) == 1:
-        return hass.data[DOMAIN][vehicle_identifiers[0]]
+    coordinators = list(hass.data[DOMAIN].keys())
+    if len(coordinators) == 1:
+        return hass.data[DOMAIN][coordinators[0]]
     else:
         device_entry = device_registry.async_get(hass).async_get(
             call.data[ATTR_DEVICE_ID]

--- a/custom_components/kia_uvo/services.py
+++ b/custom_components/kia_uvo/services.py
@@ -145,25 +145,28 @@ def _get_vehicle_id_from_device(hass: HomeAssistant, call: ServiceCall) -> str:
             vehicle_id = entry[1]
     return vehicle_id
 
-
 def _get_coordinator_from_device(
     hass: HomeAssistant, call: ServiceCall
 ) -> HyundaiKiaConnectDataUpdateCoordinator:
-    device_entry = device_registry.async_get(hass).async_get(call.data[ATTR_DEVICE_ID])
-    config_entry_ids = device_entry.config_entries
-    config_entry_id = next(
-        (
+    vehicle_identifiers = list(hass.data[DOMAIN].keys())
+    if len(vehicle_identifiers) == 1:
+        return hass.data[DOMAIN][vehicle_identifiers[0]]
+    else:
+        device_entry = device_registry.async_get(hass).async_get(call.data[ATTR_DEVICE_ID])
+        config_entry_ids = device_entry.config_entries
+        config_entry_id = next(
+            (
+                config_entry_id
+                for config_entry_id in config_entry_ids
+                if cast(
+                    ConfigEntry,
+                    hass.config_entries.async_get_entry(config_entry_id),
+                ).domain
+                == DOMAIN
+            ),
+            None,
+        )
+        config_entry_unique_id = hass.config_entries.async_get_entry(
             config_entry_id
-            for config_entry_id in config_entry_ids
-            if cast(
-                ConfigEntry,
-                hass.config_entries.async_get_entry(config_entry_id),
-            ).domain
-            == DOMAIN
-        ),
-        None,
-    )
-    config_entry_unique_id = hass.config_entries.async_get_entry(
-        config_entry_id
-    ).unique_id
-    return hass.data[DOMAIN][config_entry_unique_id]
+        ).unique_id
+        return hass.data[DOMAIN][config_entry_unique_id]

--- a/custom_components/kia_uvo/services.py
+++ b/custom_components/kia_uvo/services.py
@@ -145,6 +145,7 @@ def _get_vehicle_id_from_device(hass: HomeAssistant, call: ServiceCall) -> str:
             vehicle_id = entry[1]
     return vehicle_id
 
+
 def _get_coordinator_from_device(
     hass: HomeAssistant, call: ServiceCall
 ) -> HyundaiKiaConnectDataUpdateCoordinator:
@@ -152,7 +153,9 @@ def _get_coordinator_from_device(
     if len(vehicle_identifiers) == 1:
         return hass.data[DOMAIN][vehicle_identifiers[0]]
     else:
-        device_entry = device_registry.async_get(hass).async_get(call.data[ATTR_DEVICE_ID])
+        device_entry = device_registry.async_get(hass).async_get(
+            call.data[ATTR_DEVICE_ID]
+        )
         config_entry_ids = device_entry.config_entries
         config_entry_id = next(
             (

--- a/custom_components/kia_uvo/services.yaml
+++ b/custom_components/kia_uvo/services.yaml
@@ -4,7 +4,7 @@ force_update:
     device_id: 
       name: Vehicle
       description: Target vehicle
-      required: true
+      required: false
       selector: 
         device: 
           integration: kia_uvo
@@ -14,7 +14,7 @@ update:
     device_id: 
       name: Vehicle
       description: Target vehicle
-      required: true
+      required: false
       selector: 
         device: 
           integration: kia_uvo


### PR DESCRIPTION
First step of no longer needing a device selected for service calls.  This removes the requirement for Update and Force Update.

#533 