### PR TITLE
fix: Vehicle no longer required for all service calls

### DIFF
--- a/custom_components/kia_uvo/services.py
+++ b/custom_components/kia_uvo/services.py
@@ -139,6 +139,13 @@ def async_unload_services(hass) -> None:
 
 
 def _get_vehicle_id_from_device(hass: HomeAssistant, call: ServiceCall) -> str:
+    coordinators = list(hass.data[DOMAIN].keys())
+    if len(coordinators) == 1:
+        coordinator = hass.data[DOMAIN][coordinators[0]]
+        vehicles = coordinator.vehicle_manager.vehicles
+        if len(vehicles) == 1:
+            return list(vehicles.keys())[0]
+      
     device_entry = device_registry.async_get(hass).async_get(call.data[ATTR_DEVICE_ID])
     for entry in device_entry.identifiers:
         if entry[0] == DOMAIN:

--- a/custom_components/kia_uvo/services.py
+++ b/custom_components/kia_uvo/services.py
@@ -145,7 +145,7 @@ def _get_vehicle_id_from_device(hass: HomeAssistant, call: ServiceCall) -> str:
         vehicles = coordinator.vehicle_manager.vehicles
         if len(vehicles) == 1:
             return list(vehicles.keys())[0]
-      
+
     device_entry = device_registry.async_get(hass).async_get(call.data[ATTR_DEVICE_ID])
     for entry in device_entry.identifiers:
         if entry[0] == DOMAIN:

--- a/custom_components/kia_uvo/services.yaml
+++ b/custom_components/kia_uvo/services.yaml
@@ -23,8 +23,8 @@ start_climate:
   fields: 
     device_id:
       name: Vehicle
-      description: Target vehicle
-      required: true
+      description: Target vehicle, if a single vehicle will use that by default.
+      required: false
       selector: 
         device: 
           integration: kia_uvo
@@ -182,7 +182,7 @@ stop_climate:
     device_id: 
       name: Vehicle
       description: Target vehicle 
-      required: true
+      required: false
       selector: 
         device: 
           integration: kia_uvo
@@ -192,7 +192,7 @@ start_charge:
     device_id: 
       name: Vehicle
       description: Target vehicle
-      required: true
+      required: false
       selector: 
         device: 
           integration: kia_uvo
@@ -202,7 +202,7 @@ stop_charge:
     device_id: 
       name: Vehicle
       description: Target vehicle
-      required: true
+      required: false
       selector: 
         device: 
           integration: kia_uvo
@@ -212,7 +212,7 @@ lock:
     device_id: 
       name: Vehicle
       description: Target vehicle
-      required: true
+      required: false
       selector: 
         device: 
           integration: kia_uvo
@@ -222,7 +222,7 @@ unlock:
     device_id: 
       name: Vehicle
       description: Target vehicle
-      required: true
+      required: false
       selector: 
         device: 
           integration: kia_uvo
@@ -232,7 +232,7 @@ close_charge_port:
     device_id: 
       name: Vehicle
       description: Target vehicle
-      required: true
+      required: false
       selector: 
         device: 
           integration: kia_uvo
@@ -242,7 +242,7 @@ open_charge_port:
     device_id: 
       name: Vehicle
       description: Target vehicle
-      required: true
+      required: false
       selector: 
         device: 
           integration: kia_uvo        
@@ -252,7 +252,7 @@ set_charge_limits:
     device_id: 
       name: Vehicle
       description: Target vehicle
-      required: true
+      required: false
       selector: 
         device: 
           integration: kia_uvo


### PR DESCRIPTION
I don't think ideal checking the API for vehicle count instead of home assistant but seemed easier.  #533 