### PR TITLE
fix: Change odometer state_class to total_increasing

### DIFF
--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -44,7 +44,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         icon="mdi:speedometer",
         native_unit_of_measurement=DYNAMIC_UNIT,
         device_class=SensorDeviceClass.DISTANCE,
-        state_class=SensorStateClass.MEASUREMENT,
+        state_class=SensorStateClass.TOTAL_INCREASING,
     ),
     SensorEntityDescription(
         key="_last_service_distance",


### PR DESCRIPTION
Since the odometer  is a value that is only destined to increase, total_increasing should be the most suitable option.

Moreover this should resolve some erratical statistics when the sensor becomes unavailable (statistics card and graphs, daily mileage when feeding an utilty meter etc)