### PR TITLE
feat: Change the Charge Limit from BOX to SLIDER

### DIFF
--- a/custom_components/kia_uvo/number.py
+++ b/custom_components/kia_uvo/number.py
@@ -78,7 +78,7 @@ class HyundaiKiaConnectNumber(NumberEntity, HyundaiKiaConnectEntity):
         self._key = self._description.key
         self._attr_unique_id = f"{DOMAIN}_{vehicle.id}_{self._key}"
         self._attr_icon = self._description.icon
-        self._attr_mode = NumberMode.BOX
+        self._attr_mode = NumberMode.SLIDER
         self._attr_name = f"{vehicle.name} {self._description.name}"
         self._attr_device_class = self._description.device_class
 


### PR DESCRIPTION
This makes the change of charge limit much more convenient. Previously, with BOX, it's impossible to change the limit. If you delete one digit, it goes to 50; if you add a digit, it goes to 100. Now the life is made easier.