### PR TITLE
fix: bump dependent hyundai_kia_connect_api version to 3.8.4

### DIFF
--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/fuatakgun/kia_uvo/issues",
-  "requirements": ["hyundai_kia_connect_api==3.6.0"],
+  "requirements": ["hyundai_kia_connect_api==3.8.4"],
   "version": "2.11.0"
 }


### PR DESCRIPTION
note: don't merge until the version is manually bumped in `hyundai_kia_connect_api`.

this pr updates the dependency to get the latest Australia fixes. 