### PR TITLE
[Bugfix] Vehicle data sensor was only created for the last vehicle and not all

### DIFF
--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -228,11 +228,10 @@ async def async_setup_entry(
                 entities.append(
                     HyundaiKiaConnectSensor(coordinator, description, vehicle)
                 )
+        entities.append(
+            VehicleEntity(coordinator, coordinator.vehicle_manager.vehicles[vehicle_id])
+        )
     async_add_entities(entities)
-    async_add_entities(
-        [VehicleEntity(coordinator, coordinator.vehicle_manager.vehicles[vehicle_id])],
-        True,
-    )
     return True
 
 


### PR DESCRIPTION
Hello,
I noticed that the sensor providing the raw vehicle data from the API was only created for the last vehicle and not all of them since it was set up outside of the vehicle loop.
I'm pretty sure that this in not intended and therefore implemented a fix.
Best regards.