### PR TITLE
feat: Addition of a binary sensor for brake fluid warning.

### DIFF
--- a/custom_components/kia_uvo/binary_sensor.py
+++ b/custom_components/kia_uvo/binary_sensor.py
@@ -253,6 +253,14 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         on_icon="mdi:clock-outline",
         off_icon="mdi:clock-outline",
     ),
+    HyundaiKiaBinarySensorEntityDescription(
+        key="brake_fluid_warning_is_on",
+        name="Brake Fluid Warning",
+        is_on=lambda vehicle: vehicle.brake_fluid_warning_is_on,
+        on_icon="mdi:car-brake-alert",
+        off_icon="mdi:car-brake-fluid-level",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+    ),
 )
 
 


### PR DESCRIPTION
Hello,

this commit adds a new binary_sensor for the status of the brake fluid warning field.
It is almost identical to the already existing washer fluid warning sensor.

Best regards