### PR TITLE
feat: Addition of sensor for Total Power Regenerated

### DIFF
--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -146,7 +146,15 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
     ),
     SensorEntityDescription(
         key="total_power_consumed",
-        name="Monthly Energy Consumption",
+        name="Total Energy Consumption",
+        icon="mdi:car-electric",
+        native_unit_of_measurement=ENERGY_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+    SensorEntityDescription(
+        key="total_power_regenerated",
+        name="Total Energy Regeneration",
         icon="mdi:car-electric",
         native_unit_of_measurement=ENERGY_WATT_HOUR,
         device_class=SensorDeviceClass.ENERGY,


### PR DESCRIPTION
Hello,

this PR adds a sensor for the "total_power_regenerated" field which is already present in the API but not yet included in the Home Assistant integration. Following to the naming of the sensor for the field "total_power_consumed" which is already existing, the sensor should be named "Monthly Energy Regeneration", but as I stated in issue #751 I think there are multiple indications that the naming "Monthly" is wrong and should actually be "Total" like in the field name, so I named the sensor "Total Energy Regeneration" - Please correct me if I'm wrong.

Best regards