### PR TITLE
feat: Addition of sensor for the daily driving stats data.

### DIFF
--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -230,7 +230,9 @@ async def async_setup_entry(
                     HyundaiKiaConnectSensor(coordinator, description, vehicle)
                 )
         entities.append(
-            DailyDrivingStatsEntity(coordinator, coordinator.vehicle_manager.vehicles[vehicle_id])
+            DailyDrivingStatsEntity(
+                coordinator, coordinator.vehicle_manager.vehicles[vehicle_id]
+            )
         )
     async_add_entities(entities)
     async_add_entities(
@@ -304,6 +306,7 @@ class VehicleEntity(SensorEntity, HyundaiKiaConnectEntity):
     def unique_id(self):
         return f"{DOMAIN}-all-data-{self.vehicle.id}"
 
+
 class DailyDrivingStatsEntity(SensorEntity, HyundaiKiaConnectEntity):
     def __init__(self, coordinator, vehicle: Vehicle):
         super().__init__(coordinator, vehicle)
@@ -340,4 +343,3 @@ class DailyDrivingStatsEntity(SensorEntity, HyundaiKiaConnectEntity):
     @property
     def unit_of_measurement(self):
         return TIME_DAYS
-

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -16,6 +16,7 @@ from homeassistant.components.sensor import (
 from homeassistant.const import (
     PERCENTAGE,
     TIME_MINUTES,
+    TIME_DAYS,
     ENERGY_WATT_HOUR,
     ENERGY_KILO_WATT_HOUR,
 )
@@ -228,6 +229,9 @@ async def async_setup_entry(
                 entities.append(
                     HyundaiKiaConnectSensor(coordinator, description, vehicle)
                 )
+        entities.append(
+            DailyDrivingStatsEntity(coordinator, coordinator.vehicle_manager.vehicles[vehicle_id])
+        )
     async_add_entities(entities)
     async_add_entities(
         [VehicleEntity(coordinator, coordinator.vehicle_manager.vehicles[vehicle_id])],
@@ -299,3 +303,41 @@ class VehicleEntity(SensorEntity, HyundaiKiaConnectEntity):
     @property
     def unique_id(self):
         return f"{DOMAIN}-all-data-{self.vehicle.id}"
+
+class DailyDrivingStatsEntity(SensorEntity, HyundaiKiaConnectEntity):
+    def __init__(self, coordinator, vehicle: Vehicle):
+        super().__init__(coordinator, vehicle)
+
+    @property
+    def state(self):
+        return len(self.vehicle.daily_stats)
+
+    @property
+    def state_attributes(self):
+        m = {}
+        for day in self.vehicle.daily_stats:
+            key = day.date.date()
+            value = {
+                "total_consumed": day.total_consumed,
+                "engine_consumption": day.engine_consumption,
+                "climate_consumption": day.climate_consumption,
+                "onboard_electronics_consumption": day.onboard_electronics_consumption,
+                "battery_care_consumption": day.battery_care_consumption,
+                "regenerated_energy": day.regenerated_energy,
+                "distance": day.distance,
+            }
+            m[key] = value
+        return m
+
+    @property
+    def name(self):
+        return f"{self.vehicle.name} Daily Driving Stats"
+
+    @property
+    def unique_id(self):
+        return f"{DOMAIN}-daily-driving-stats-{self.vehicle.id}"
+
+    @property
+    def unit_of_measurement(self):
+        return TIME_DAYS
+


### PR DESCRIPTION
Hello,

this PR adds a sensor containing the data stored in the daily_stats field of the Vehicle objects since currently these data are not accessible in Home Assistant. The data are contained in the attributes of the sensor - one attribute per day which is identified via a datetime.date object. The values of each day are stored in a dictionay with the same keys used by the hyundai_kia_connect_api. I think having such a sensor is very useful to further process the data by e.g. templates.

Best regards