### PR TITLE
fix: Workaround to overcome limiations in InfluxDB

### DIFF
--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -326,7 +326,7 @@ class DailyDrivingStatsEntity(SensorEntity, HyundaiKiaConnectEntity):
     def state_attributes(self):
         m = {}
         for day in self.vehicle.daily_stats:
-            key = day.date.date()
+            key = day.date.strftime("%Y-%m-%d")
             value = {
                 "total_consumed": day.total_consumed,
                 "engine_consumption": day.engine_consumption,


### PR DESCRIPTION
Hello,

as discussed in issue #755 this PR changes the datatype of the attribute keys of the daily driving stats sensor to string using the default date-format of Python "%Y-%m-%d". I hard-coded the format to avoid problems if for any reason the default date to string conversion of Python should change in the future. The change is neccessary to overcome the limitation of the InfluxDB integration which at the moment allows only for string-type attribute keys.

Best regards.