### PR TITLE
chore: bump hyundai_kia_connect_api to 3.17.0

### DIFF
--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "kia_uvo",
-  "name": "Kia Uvo / Hyundai Bluelink",
+  "name": "Kia Uvo / Hyundai Bluelink (AUSTRALIA TEST)",
   "codeowners": ["@fuatakgun"],
   "config_flow": true,
   "documentation": "https://github.com/Hyundai-Kia-Connect/kia_uvo",

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Hyundai-Kia-Connect/kia_uvo/issues",
-  "requirements": ["hyundai_kia_connect_api==3.15.1"],
+  "requirements": ["hyundai_kia_connect_api==3.17.0"],
   "version": "2.20.1"
 }


### PR DESCRIPTION
Testing first - do not merge.

This PR just bumps the hyundai_kia_connect_api depedency to v3.17.0, to add Kia Australia support.