### PR TITLE
feat: Add Measurement state_class to EV Battery Level

### DIFF
--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -77,6 +77,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         name="EV Battery Level",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(
         key="ev_battery_soh_percentage",


### PR DESCRIPTION
We want to have state_class defined to have it stored in long term statistics.

More information:
https://developers.home-assistant.io/blog/2021/05/25/sensor_attributes/