### PR TITLE
feat: calls update state on completion

### DIFF
--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -167,63 +167,69 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
             self.vehicle_manager.check_and_refresh_token
         )
 
+    async def async_await_action_and_refresh(self, vehicle_id, action_id):
+        await self.hass.async_add_executor_job(
+            self.vehicle_manager.check_action_status, vehicle_id, action_id, True, 60
+        )
+        await self.async_refresh()
+
     async def async_lock_vehicle(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(self.vehicle_manager.lock, vehicle_id)
-        await self.async_request_refresh()
+        action_id = await self.hass.async_add_executor_job(self.vehicle_manager.lock, vehicle_id)
+        self.hass.async_create_task(self.async_await_action_and_refresh(vehicle_id, action_id))
 
     async def async_unlock_vehicle(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(self.vehicle_manager.unlock, vehicle_id)
-        await self.async_request_refresh()
+        action_id = await self.hass.async_add_executor_job(self.vehicle_manager.unlock, vehicle_id)
+        self.hass.async_create_task(self.async_await_action_and_refresh(vehicle_id, action_id))
 
     async def async_open_charge_port(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
+        action_id = await self.hass.async_add_executor_job(
             self.vehicle_manager.open_charge_port, vehicle_id
         )
-        await self.async_request_refresh()
+        self.hass.async_create_task(self.async_await_action_and_refresh(vehicle_id, action_id))
 
     async def async_close_charge_port(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
+        action_id = await self.hass.async_add_executor_job(
             self.vehicle_manager.close_charge_port, vehicle_id
         )
-        await self.async_request_refresh()
+        self.hass.async_create_task(self.async_await_action_and_refresh(vehicle_id, action_id))
 
     async def async_start_climate(
         self, vehicle_id: str, climate_options: ClimateRequestOptions
     ):
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
+        action_id = await self.hass.async_add_executor_job(
             self.vehicle_manager.start_climate, vehicle_id, climate_options
         )
-        await self.async_request_refresh()
+        self.hass.async_create_task(self.async_await_action_and_refresh(vehicle_id, action_id))
 
     async def async_stop_climate(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
+        action_id = await self.hass.async_add_executor_job(
             self.vehicle_manager.stop_climate, vehicle_id
         )
-        await self.async_request_refresh()
+        self.hass.async_create_task(self.async_await_action_and_refresh(vehicle_id, action_id))
 
     async def async_start_charge(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
+        action_id = await self.hass.async_add_executor_job(
             self.vehicle_manager.start_charge, vehicle_id
         )
-        await self.async_request_refresh()
+        self.hass.async_create_task(self.async_await_action_and_refresh(vehicle_id, action_id))
 
     async def async_stop_charge(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
+        action_id = await self.hass.async_add_executor_job(
             self.vehicle_manager.stop_charge, vehicle_id
         )
-        await self.async_request_refresh()
+        self.hass.async_create_task(self.async_await_action_and_refresh(vehicle_id, action_id))
 
     async def set_charge_limits(self, vehicle_id: str, ac: int, dc: int):
         await self.async_check_and_refresh_token()
-        await self.hass.async_add_executor_job(
+        action_id = await self.hass.async_add_executor_job(
             self.vehicle_manager.set_charge_limits, vehicle_id, ac, dc
         )
-        await self.async_request_refresh()
+        self.hass.async_create_task(self.async_await_action_and_refresh(vehicle_id, action_id))

--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -170,34 +170,50 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
     async def async_await_action_and_refresh(self, vehicle_id, action_id):
         try:
             await self.hass.async_add_executor_job(
-                self.vehicle_manager.check_action_status, vehicle_id, action_id, True, 60
+                self.vehicle_manager.check_action_status,
+                vehicle_id,
+                action_id,
+                True,
+                60,
             )
         finally:
             await self.async_refresh()
 
     async def async_lock_vehicle(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        action_id = await self.hass.async_add_executor_job(self.vehicle_manager.lock, vehicle_id)
-        self.hass.async_create_task(self.async_await_action_and_refresh(vehicle_id, action_id))
+        action_id = await self.hass.async_add_executor_job(
+            self.vehicle_manager.lock, vehicle_id
+        )
+        self.hass.async_create_task(
+            self.async_await_action_and_refresh(vehicle_id, action_id)
+        )
 
     async def async_unlock_vehicle(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
-        action_id = await self.hass.async_add_executor_job(self.vehicle_manager.unlock, vehicle_id)
-        self.hass.async_create_task(self.async_await_action_and_refresh(vehicle_id, action_id))
+        action_id = await self.hass.async_add_executor_job(
+            self.vehicle_manager.unlock, vehicle_id
+        )
+        self.hass.async_create_task(
+            self.async_await_action_and_refresh(vehicle_id, action_id)
+        )
 
     async def async_open_charge_port(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
         action_id = await self.hass.async_add_executor_job(
             self.vehicle_manager.open_charge_port, vehicle_id
         )
-        self.hass.async_create_task(self.async_await_action_and_refresh(vehicle_id, action_id))
+        self.hass.async_create_task(
+            self.async_await_action_and_refresh(vehicle_id, action_id)
+        )
 
     async def async_close_charge_port(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
         action_id = await self.hass.async_add_executor_job(
             self.vehicle_manager.close_charge_port, vehicle_id
         )
-        self.hass.async_create_task(self.async_await_action_and_refresh(vehicle_id, action_id))
+        self.hass.async_create_task(
+            self.async_await_action_and_refresh(vehicle_id, action_id)
+        )
 
     async def async_start_climate(
         self, vehicle_id: str, climate_options: ClimateRequestOptions
@@ -206,32 +222,42 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
         action_id = await self.hass.async_add_executor_job(
             self.vehicle_manager.start_climate, vehicle_id, climate_options
         )
-        self.hass.async_create_task(self.async_await_action_and_refresh(vehicle_id, action_id))
+        self.hass.async_create_task(
+            self.async_await_action_and_refresh(vehicle_id, action_id)
+        )
 
     async def async_stop_climate(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
         action_id = await self.hass.async_add_executor_job(
             self.vehicle_manager.stop_climate, vehicle_id
         )
-        self.hass.async_create_task(self.async_await_action_and_refresh(vehicle_id, action_id))
+        self.hass.async_create_task(
+            self.async_await_action_and_refresh(vehicle_id, action_id)
+        )
 
     async def async_start_charge(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
         action_id = await self.hass.async_add_executor_job(
             self.vehicle_manager.start_charge, vehicle_id
         )
-        self.hass.async_create_task(self.async_await_action_and_refresh(vehicle_id, action_id))
+        self.hass.async_create_task(
+            self.async_await_action_and_refresh(vehicle_id, action_id)
+        )
 
     async def async_stop_charge(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
         action_id = await self.hass.async_add_executor_job(
             self.vehicle_manager.stop_charge, vehicle_id
         )
-        self.hass.async_create_task(self.async_await_action_and_refresh(vehicle_id, action_id))
+        self.hass.async_create_task(
+            self.async_await_action_and_refresh(vehicle_id, action_id)
+        )
 
     async def set_charge_limits(self, vehicle_id: str, ac: int, dc: int):
         await self.async_check_and_refresh_token()
         action_id = await self.hass.async_add_executor_job(
             self.vehicle_manager.set_charge_limits, vehicle_id, ac, dc
         )
-        self.hass.async_create_task(self.async_await_action_and_refresh(vehicle_id, action_id))
+        self.hass.async_create_task(
+            self.async_await_action_and_refresh(vehicle_id, action_id)
+        )

--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -168,10 +168,12 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
         )
 
     async def async_await_action_and_refresh(self, vehicle_id, action_id):
-        await self.hass.async_add_executor_job(
-            self.vehicle_manager.check_action_status, vehicle_id, action_id, True, 60
-        )
-        await self.async_refresh()
+        try:
+            await self.hass.async_add_executor_job(
+                self.vehicle_manager.check_action_status, vehicle_id, action_id, True, 60
+            )
+        finally:
+            await self.async_refresh()
 
     async def async_lock_vehicle(self, vehicle_id: str):
         await self.async_check_and_refresh_token()

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Hyundai-Kia-Connect/kia_uvo/issues",
   "loggers": ["kia_uvo", "hyundai_kia_connect_api"],
-  "requirements": ["hyundai_kia_connect_api==3.20.6"],
+  "requirements": ["hyundai_kia_connect_api==3.20.7"],
   "version": "2.24.5"
 }


### PR DESCRIPTION
Calls to lock, unlock, start_climate, stop_climate, start_charge, stop_charge and set_charge_limits now update the state of the vehicle when complete.

TL/DR: ``await async_request_refresh()`` has been replaced by ``don't await, async try to wait until action is done and finally async_refresh()``. The try block should ensure that this feature is completely neutral or additive.

This was done by adding a new ``async_await_action_and_refresh`` function to the coordinator. It adds ``check_action_status`` that awaits for success or error before calling ``async_refresh``. This function is called using ``async_create_task`` so that the action can finish without having to wait for a response that can take about 30 to 60 seconds. Since the function now waits for the action to complete before refreshing, the refreshed state now has the updated (post-action) information, updating the UI with the new status. To help avoid any possible bugs in regions that don't have check_action_status properly implemented ([HyundaiBlueLinkAPIUSA](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/blob/master/hyundai_kia_connect_api/HyundaiBlueLinkAPIUSA.py) which doesn't have that function and [KiaUvoAPIUSA](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/blob/master/hyundai_kia_connect_api/KiaUvoAPIUSA.py) which doesn't implement the synchronous feature), check_action_status is wrapped in a try block, with a finally block that calls for a refresh, just as it did before.

This has been tested with lock, unlock, start_climate and stop_climate in CA and works as expected.