### PR TITLE
fix: charging current initialisation

### DIFF
--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -249,6 +249,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
     ),
 )
 
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -297,8 +298,8 @@ class HyundaiKiaConnectSensor(SensorEntity, HyundaiKiaConnectEntity):
     def native_value(self):
         """Return the value reported by the sensor."""
         value = getattr(self.vehicle, self._key)
-        if (self._key == "ev_charging_current"):
-           return CHARGING_CURRENTS.get(value, None)
+        if self._key == "ev_charging_current":
+            return CHARGING_CURRENTS.get(value, None)
         return value
 
     @property

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -245,10 +245,9 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         name="Charging Current Limit",
         icon="mdi:lightning-bolt-circle",
         native_unit_of_measurement=PERCENTAGE,
-        value_fn=charging_current_mapper,
+        device_class=SensorDeviceClass.POWER_FACTOR,
     ),
 )
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -297,7 +296,10 @@ class HyundaiKiaConnectSensor(SensorEntity, HyundaiKiaConnectEntity):
     @property
     def native_value(self):
         """Return the value reported by the sensor."""
-        return getattr(self.vehicle, self._key)
+        value = getattr(self.vehicle, self._key)
+        if (self._key == "ev_charging_current"):
+           return CHARGING_CURRENTS.get(value, None)
+        return value
 
     @property
     def native_unit_of_measurement(self):
@@ -379,7 +381,3 @@ class DailyDrivingStatsEntity(SensorEntity, HyundaiKiaConnectEntity):
     @property
     def unit_of_measurement(self):
         return UnitOfTime.DAYS
-
-
-def charging_current_mapper(value):
-    return CHARGING_CURRENTS.get(value, None)

--- a/custom_components/kia_uvo/services.py
+++ b/custom_components/kia_uvo/services.py
@@ -163,6 +163,7 @@ def async_setup_services(hass: HomeAssistant) -> bool:
         SERVICE_SET_CHARGE_LIMIT: async_handle_set_charge_limit,
         SERVICE_OPEN_CHARGE_PORT: async_handle_open_charge_port,
         SERVICE_CLOSE_CHARGE_PORT: async_handle_close_charge_port,
+        SERVICE_SET_CHARGING_CURRENT: async_handle_set_charging_current,
     }
 
     for service in SUPPORTED_SERVICES:


### PR DESCRIPTION
Sorry, had to rework the `value_fn` since that was not available on the SensorEntityDescription.
Furthermore I forgot to add it to the services setup... my bad.