### PR TITLE
feat: Add Sensor for todays daily stats

### DIFF
--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -364,8 +364,6 @@ class DailyDrivingStatsEntity(SensorEntity, HyundaiKiaConnectEntity):
         m = {}
         for day in self.vehicle.daily_stats:
             key = day.date.strftime("%Y-%m-%d")
-            today = date.today()
-            todayskey = today.strftime("%Y-%m-%d")
             value = {
                 "total_consumed": day.total_consumed,
                 "engine_consumption": day.engine_consumption,
@@ -375,18 +373,6 @@ class DailyDrivingStatsEntity(SensorEntity, HyundaiKiaConnectEntity):
                 "regenerated_energy": day.regenerated_energy,
                 "distance": day.distance,
             }
-            if key == todayskey:
-                todayvalue = {
-                    "today_date": key,
-                    "total_consumed": day.total_consumed,
-                    "engine_consumption": day.engine_consumption,
-                    "climate_consumption": day.climate_consumption,
-                    "onboard_electronics_consumption": day.onboard_electronics_consumption,
-                    "battery_care_consumption": day.battery_care_consumption,
-                    "regenerated_energy": day.regenerated_energy,
-                    "distance": day.distance,
-                }
-                m["today"] = todayvalue
             m[key] = value
         return m
 

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -412,7 +412,7 @@ class TodaysDailyDrivingStatsEntity(SensorEntity, HyundaiKiaConnectEntity):
             "battery_care_consumption": 0,
             "regenerated_energy": 0,
             "distance": 0,
-            }
+        }
         for day in self.vehicle.daily_stats:
             key = day.date.strftime("%Y-%m-%d")
             if key == todayskey:

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from typing import Final
+from datetime import date
 
 from hyundai_kia_connect_api import Vehicle
 
@@ -270,6 +271,11 @@ async def async_setup_entry(
                     coordinator, coordinator.vehicle_manager.vehicles[vehicle_id]
                 )
             )
+            entities.append(
+                TodaysDailyDrivingStatsEntity(
+                    coordinator, coordinator.vehicle_manager.vehicles[vehicle_id]
+                )
+            )
         entities.append(
             VehicleEntity(coordinator, coordinator.vehicle_manager.vehicles[vehicle_id])
         )
@@ -358,6 +364,8 @@ class DailyDrivingStatsEntity(SensorEntity, HyundaiKiaConnectEntity):
         m = {}
         for day in self.vehicle.daily_stats:
             key = day.date.strftime("%Y-%m-%d")
+            today = date.today()
+            todayskey = today.strftime("%Y-%m-%d")
             value = {
                 "total_consumed": day.total_consumed,
                 "engine_consumption": day.engine_consumption,
@@ -367,6 +375,18 @@ class DailyDrivingStatsEntity(SensorEntity, HyundaiKiaConnectEntity):
                 "regenerated_energy": day.regenerated_energy,
                 "distance": day.distance,
             }
+            if key == todayskey:
+                todayvalue = {
+                    "today_date": key,
+                    "total_consumed": day.total_consumed,
+                    "engine_consumption": day.engine_consumption,
+                    "climate_consumption": day.climate_consumption,
+                    "onboard_electronics_consumption": day.onboard_electronics_consumption,
+                    "battery_care_consumption": day.battery_care_consumption,
+                    "regenerated_energy": day.regenerated_energy,
+                    "distance": day.distance,
+                }
+                m["today"] = todayvalue
             m[key] = value
         return m
 
@@ -381,3 +401,53 @@ class DailyDrivingStatsEntity(SensorEntity, HyundaiKiaConnectEntity):
     @property
     def unit_of_measurement(self):
         return UnitOfTime.DAYS
+
+
+class TodaysDailyDrivingStatsEntity(SensorEntity, HyundaiKiaConnectEntity):
+    def __init__(self, coordinator, vehicle: Vehicle):
+        super().__init__(coordinator, vehicle)
+
+    @property
+    def state(self):
+        today = date.today()
+        todayskey = today.strftime("%Y-%m-%d")
+        return todayskey
+
+    @property
+    def state_attributes(self):
+        today = date.today()
+        todayskey = today.strftime("%Y-%m-%d")
+        m = {
+            "today_date": todayskey,
+            "total_consumed": 0,
+            "engine_consumption": 0,
+            "climate_consumption": 0,
+            "onboard_electronics_consumption": 0,
+            "battery_care_consumption": 0,
+            "regenerated_energy": 0,
+            "distance": 0,
+            }
+        for day in self.vehicle.daily_stats:
+            key = day.date.strftime("%Y-%m-%d")
+            if key == todayskey:
+                todayvalue = {
+                    "today_date": key,
+                    "total_consumed": day.total_consumed,
+                    "engine_consumption": day.engine_consumption,
+                    "climate_consumption": day.climate_consumption,
+                    "onboard_electronics_consumption": day.onboard_electronics_consumption,
+                    "battery_care_consumption": day.battery_care_consumption,
+                    "regenerated_energy": day.regenerated_energy,
+                    "distance": day.distance,
+                }
+                m = todayvalue
+                break
+        return m
+
+    @property
+    def name(self):
+        return f"{self.vehicle.name} Todays Daily Driving Stats"
+
+    @property
+    def unique_id(self):
+        return f"{DOMAIN}-todays-daily-driving-stats-{self.vehicle.id}"


### PR DESCRIPTION
Adds a sensor for "Todays Daily Driving Stats" which allows for a fixed sensor to access daily stats instead of the moving target of the date labeled attribute in the main daily driving stats sensor.

This makes it easier to pull the current days stats and have it reset at midnight as it will switch to default 0 values. instead of using template workarounds such as those discussed in #870 or other helper implementations people may be using.

the entity gets added along with the normal Daily Driving Stats so it only exists if that does and draws data using the same method.

NB: 1st PR on a HA integration, please be kind.