### PR TITLE
feat!: Switch select sensors to diagnostic category

### DIFF
--- a/custom_components/kia_uvo/binary_sensor.py
+++ b/custom_components/kia_uvo/binary_sensor.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 import logging
 from typing import Final
 
+from homeassistant.const import EntityCategory
 from hyundai_kia_connect_api import Vehicle
 
 from homeassistant.components.binary_sensor import (
@@ -41,6 +42,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         is_on=lambda vehicle: vehicle.engine_is_running,
         on_icon="mdi:engine",
         off_icon="mdi:engine-off",
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="defrost_is_on",
@@ -48,6 +50,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         is_on=lambda vehicle: vehicle.defrost_is_on,
         on_icon="mdi:car-defrost-front",
         off_icon="mdi:car-defrost-front",
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="steering_wheel_heater_is_on",
@@ -55,6 +58,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         is_on=lambda vehicle: vehicle.steering_wheel_heater_is_on,
         on_icon="mdi:steering",
         off_icon="mdi:steering",
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="back_window_heater_is_on",
@@ -62,6 +66,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         is_on=lambda vehicle: vehicle.back_window_heater_is_on,
         on_icon="mdi:car-defrost-rear",
         off_icon="mdi:car-defrost-rear",
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="side_mirror_heater_is_on",
@@ -69,6 +74,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         is_on=lambda vehicle: vehicle.side_mirror_heater_is_on,
         on_icon="mdi:car-side",
         off_icon="mdi:car-side",
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="front_left_door_is_open",
@@ -77,6 +83,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         on_icon="mdi:car-door",
         off_icon="mdi:car-door",
         device_class=BinarySensorDeviceClass.DOOR,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="front_right_door_is_open",
@@ -85,6 +92,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         on_icon="mdi:car-door",
         off_icon="mdi:car-door",
         device_class=BinarySensorDeviceClass.DOOR,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="back_left_door_is_open",
@@ -93,6 +101,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         on_icon="mdi:car-door",
         off_icon="mdi:car-door",
         device_class=BinarySensorDeviceClass.DOOR,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="back_right_door_is_open",
@@ -101,6 +110,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         on_icon="mdi:car-door",
         off_icon="mdi:car-door",
         device_class=BinarySensorDeviceClass.DOOR,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="trunk_is_open",
@@ -109,6 +119,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         on_icon="mdi:car-back",
         off_icon="mdi:car-back",
         device_class=BinarySensorDeviceClass.DOOR,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="hood_is_open",
@@ -117,6 +128,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         on_icon="mdi:car",
         off_icon="mdi:car",
         device_class=BinarySensorDeviceClass.DOOR,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="front_left_window_is_open",
@@ -125,6 +137,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         on_icon="mdi:car-door",
         off_icon="mdi:car-door",
         device_class=BinarySensorDeviceClass.WINDOW,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="front_right_window_is_open",
@@ -133,6 +146,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         on_icon="mdi:car-door",
         off_icon="mdi:car-door",
         device_class=BinarySensorDeviceClass.WINDOW,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="back_left_window_is_open",
@@ -141,6 +155,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         on_icon="mdi:car-door",
         off_icon="mdi:car-door",
         device_class=BinarySensorDeviceClass.WINDOW,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="back_right_window_is_open",
@@ -149,18 +164,21 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         on_icon="mdi:car-door",
         off_icon="mdi:car-door",
         device_class=BinarySensorDeviceClass.WINDOW,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="ev_battery_is_charging",
         name="EV Battery Charge",
         is_on=lambda vehicle: vehicle.ev_battery_is_charging,
         device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="ev_battery_is_plugged_in",
         name="EV Battery Plug",
         is_on=lambda vehicle: vehicle.ev_battery_is_plugged_in,
         device_class=BinarySensorDeviceClass.PLUG,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="fuel_level_is_low",
@@ -168,6 +186,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         is_on=lambda vehicle: vehicle.fuel_level_is_low,
         on_icon="mdi:gas-station-off",
         off_icon="mdi:gas-station",
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="smart_key_battery_warning_is_on",
@@ -176,6 +195,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         on_icon="mdi:battery-alert",
         off_icon="mdi:battery",
         device_class=BinarySensorDeviceClass.BATTERY,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="washer_fluid_warning_is_on",
@@ -184,6 +204,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         on_icon="mdi:wiper-wash-alert",
         off_icon="mdi:wiper-wash",
         device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="tire_pressure_all_warning_is_on",
@@ -192,6 +213,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         on_icon="mdi:car-tire-alert",
         off_icon="mdi:car-tire-alert",
         device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="tire_pressure_rear_left_warning_is_on",
@@ -200,6 +222,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         on_icon="mdi:car-tire-alert",
         off_icon="mdi:car-tire-alert",
         device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="tire_pressure_front_left_warning_is_on",
@@ -208,6 +231,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         on_icon="mdi:car-tire-alert",
         off_icon="mdi:car-tire-alert",
         device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="tire_pressure_front_right_warning_is_on",
@@ -216,6 +240,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         on_icon="mdi:car-tire-alert",
         off_icon="mdi:car-tire-alert",
         device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="tire_pressure_rear_right_warning_is_on",
@@ -224,6 +249,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         on_icon="mdi:car-tire-alert",
         off_icon="mdi:car-tire-alert",
         device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="air_control_is_on",
@@ -231,6 +257,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         is_on=lambda vehicle: vehicle.air_control_is_on,
         on_icon="mdi:air-conditioner",
         off_icon="mdi:air-conditioner",
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="ev_charge_port_door_is_open",
@@ -239,6 +266,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         on_icon="mdi:ev-station",
         off_icon="mdi:ev-station",
         device_class=BinarySensorDeviceClass.DOOR,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="ev_first_departure_enabled",
@@ -261,6 +289,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         on_icon="mdi:car-brake-alert",
         off_icon="mdi:car-brake-fluid-level",
         device_class=BinarySensorDeviceClass.PROBLEM,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )
 
@@ -298,6 +327,8 @@ class HyundaiKiaConnectBinarySensor(BinarySensorEntity, HyundaiKiaConnectEntity)
         self.entity_description: HyundaiKiaBinarySensorEntityDescription = description
         self._attr_unique_id = f"{DOMAIN}_{vehicle.id}_{description.key}"
         self._attr_name = f"{vehicle.name} {description.name}"
+        if description.entity_category:
+            self._attr_entity_category = description.entity_category
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/kia_uvo/entity.py
+++ b/custom_components/kia_uvo/entity.py
@@ -21,5 +21,6 @@ class HyundaiKiaConnectEntity(CoordinatorEntity):
             identifiers={(DOMAIN, self.vehicle.id)},
             manufacturer=f"{BRANDS[self.coordinator.vehicle_manager.brand]} {REGIONS[self.coordinator.vehicle_manager.region]}",
             model=f"{self.vehicle.name} ({self.vehicle.model})",
+            name=f"{self.vehicle.name} ({self.vehicle.model})",
             serial_number=f"{self.vehicle.VIN}",
         )

--- a/custom_components/kia_uvo/entity.py
+++ b/custom_components/kia_uvo/entity.py
@@ -20,6 +20,6 @@ class HyundaiKiaConnectEntity(CoordinatorEntity):
         return DeviceInfo(
             identifiers={(DOMAIN, self.vehicle.id)},
             manufacturer=f"{BRANDS[self.coordinator.vehicle_manager.brand]} {REGIONS[self.coordinator.vehicle_manager.region]}",
-            model=self.vehicle.model,
-            name=self.vehicle.name,
+            model=f"{self.vehicle.name} ({self.vehicle.model})",
+            serial_number=f"{self.vehicle.VIN}",
         )

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -18,7 +18,8 @@ from homeassistant.const import (
     PERCENTAGE,
     UnitOfEnergy,
     UnitOfPower,
-    UnitOfTime, EntityCategory,
+    UnitOfTime,
+    EntityCategory,
 )
 
 from homeassistant.config_entries import ConfigEntry

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     PERCENTAGE,
     UnitOfEnergy,
     UnitOfPower,
-    UnitOfTime,
+    UnitOfTime, EntityCategory,
 )
 
 from homeassistant.config_entries import ConfigEntry
@@ -52,6 +52,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         icon="mdi:car-wrench",
         device_class=SensorDeviceClass.DISTANCE,
         native_unit_of_measurement=DYNAMIC_UNIT,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SensorEntityDescription(
         key="_next_service_distance",
@@ -59,6 +60,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         icon="mdi:car-wrench",
         device_class=SensorDeviceClass.DISTANCE,
         native_unit_of_measurement=DYNAMIC_UNIT,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SensorEntityDescription(
         key="car_battery_percentage",
@@ -72,6 +74,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         name="Last Updated At",
         icon="mdi:update",
         device_class=SensorDeviceClass.TIMESTAMP,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SensorEntityDescription(
         key="ev_battery_percentage",
@@ -95,6 +98,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         key="ev_battery_capacity",
         name="EV Battery Capacity",
         state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SensorEntityDescription(
         key="_ev_driving_range",
@@ -189,21 +193,25 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         key="front_left_seat_status",
         name="Front Left Seat",
         icon="mdi:car-seat-heater",
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SensorEntityDescription(
         key="front_right_seat_status",
         name="Front Right Seat",
         icon="mdi:car-seat-heater",
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SensorEntityDescription(
         key="rear_left_seat_status",
         name="Rear Left Seat",
         icon="mdi:car-seat-heater",
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SensorEntityDescription(
         key="rear_right_seat_status",
         name="Rear Right Seat",
         icon="mdi:car-seat-heater",
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SensorEntityDescription(
         key="_geocode_name",
@@ -249,6 +257,12 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+    ),
+    SensorEntityDescription(
+        key="VIN",
+        name="Vehicle Identification Number",
+        icon="mdi:identifier",
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )
 
@@ -301,6 +315,8 @@ class HyundaiKiaConnectSensor(SensorEntity, HyundaiKiaConnectEntity):
         self._attr_name = f"{vehicle.name} {self._description.name}"
         self._attr_state_class = self._description.state_class
         self._attr_device_class = self._description.device_class
+        if description.entity_category:
+            self._attr_entity_category = description.entity_category
 
     @property
     def native_value(self):


### PR DESCRIPTION
Mostly influenced by personal taste, so feel free to keep what you like and trash the rest ;)
The main reason for the changes below is to be able to easier distinguish between cars, especially if there's more than one of the same model.

## Changes

- Add VIN to sensor list
- Add the (nick)name to the displayed device info for easier distinction in case one owns two cara of the same model
- Add the VIN as serial number to the device info

| Before | After |
| ------- | ----- |
| <img width="325" alt="old_001" src="https://github.com/user-attachments/assets/b3804aa3-35f0-4a89-be66-7f0048a8d85c" /> | ![new_001](https://github.com/user-attachments/assets/b5925aaa-d919-415a-90a5-312836e20c5b) |

- Move most of the binary sensors to the diagnostic section of the entities

| Before | After |
| ------- | ----- |
| <img width="334" alt="old_002" src="https://github.com/user-attachments/assets/39cbb4d6-c62a-44a8-8354-a6ee82fd269a" /> | ![new_002](https://github.com/user-attachments/assets/8c5ea9f6-8f0f-4a8a-b9b0-5f23adf599bd) |

> [!NOTE]
> Although the internal names of the sensors now to be found under "Diagnostics" won't be changed by the new _entity_class_ the internal statistics for those may be reset!
