### PR TITLE
docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ These can be access by going to the developer tools followed by actions. These c
 | Lock Unlock                       | ✔  | ✔                | ✔  | ✔      | ✔          | ✔          | ✔    | ✔    |
 | start stop climate                | ✔  | ✔                | ✔  | ✔      | ✔          |             | ✔    | ✔    |
 | start stop charge                 | ✔  | ✔                | ✔  | ✔      | ✔          |             |       |       |
-| set charge limits                 | ✔  | not tested        | ✔  | ✔      | ✔          |             |       |       |
+| set charge limits                 | ✔  | ✔                | ✔  | ✔      | ✔          |             |       |       |
 | open and close charge port        | ✖  | ✔                | ✖  | ✖      | ✖          | ✖          | ✖    |       |
 | set windows                       | ✖  | ✔                | ✖  | ✖      | ✖          | ✖          | ✖    |       |
 | start stop hazard lights          | ✖  | ✔                | ✖  | ✖      | ✖          | ✖          | ✖    |       |


### PR DESCRIPTION
Updated README.md to show that setting the carge levels works for 2023 onwards Kia in EU.

Tested on 2024 Kia Nero EV

Set charge limits confirmed working Kia Niro EV 2024