### PR TITLE
fix: Update climate start options to allow longer duration

### DIFF
--- a/custom_components/kia_uvo/services.yaml
+++ b/custom_components/kia_uvo/services.yaml
@@ -25,9 +25,9 @@ start_climate:
       default: 5
       selector:
         number:
-          min: 5
+          min: 1
           max: 30
-          step: 5
+          step: 1
           unit_of_measurement: minutes
     climate:
       required: true

--- a/custom_components/kia_uvo/services.yaml
+++ b/custom_components/kia_uvo/services.yaml
@@ -25,9 +25,9 @@ start_climate:
       default: 5
       selector:
         number:
-          min: 1
-          max: 10
-          step: 1
+          min: 5
+          max: 30
+          step: 5
           unit_of_measurement: minutes
     climate:
       required: true

--- a/custom_components/kia_uvo/translations/en.json
+++ b/custom_components/kia_uvo/translations/en.json
@@ -72,7 +72,7 @@
         },
         "duration": {
           "name": "Duration",
-          "description": "On Duration"
+          "description": "How long to run the climate system. Maximum duration may be limited by Model/Year/Region."
         },
         "climate": {
           "name": "Climate",


### PR DESCRIPTION
The current version of the US MyHyundai app allows climate start duration to be up to 30 minutes, in 5 minute intervals. The HACS integration currently supports a maximum of 10 minutes. 

![IMG_0492](https://github.com/user-attachments/assets/f1f8fcc1-43ef-4c3c-b9e8-40e0cdc021da)
