### PR TITLE
fix: bump hyundai_kia_connect_api to 3.48.0

### DIFF
--- a/custom_components/kia_uvo/requirements.txt
+++ b/custom_components/kia_uvo/requirements.txt
@@ -1,1 +1,1 @@
-hyundai_kia_connect_api==3.44.5
+hyundai_kia_connect_api==3.48.0


### PR DESCRIPTION
Update hyundai_kia_connect_api to latest version to fix login in EU

Once this is merged, refresh_token can be used in place of password to authenticate.

This requires users to first fetch their refresh_token.