### PR TITLE
fix: inversion of locked/unlocked state in Homeassistant

### DIFF
--- a/custom_components/kia_uvo/binary_sensor.py
+++ b/custom_components/kia_uvo/binary_sensor.py
@@ -415,7 +415,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
     HyundaiKiaBinarySensorEntityDescription(
         key="is_locked",
         name="Locked",
-        is_on=lambda vehicle: vehicle.is_locked,
+        is_on=lambda vehicle: not vehicle.is_locked,
         device_class=BinarySensorDeviceClass.LOCK,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),


### PR DESCRIPTION
Hello,

I just noticed that Homeassistant uses inverse logic compared to Bluelink for the locked state. In Bluelink `true` means `locked` and `false` means `unlocked` while Homeassistant binary sensors use `true` for `unlocked` and `false` for `locked`. Therefore the state reported by Bluelink needs to be inversed.

Best regards,
Triple-S