### PR TITLE
fix: Add circuit breaker pattern for API rate limit handling

### DIFF
--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -68,6 +68,28 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
             ),
             language=hass.config.language,
         )
+
+        # Monkey patch to log API responses before they cause KeyError
+        if hasattr(self.vehicle_manager, 'api') and hasattr(self.vehicle_manager.api, '_get_vehicle_status'):
+            original_get_vehicle_status = self.vehicle_manager.api._get_vehicle_status
+
+            def logged_get_vehicle_status(token, vehicle, force_refresh):
+                """Wrapper to log API response before processing."""
+                try:
+                    # Call original method - it will make the HTTP request
+                    # We can't intercept before the dict() call, so we'll catch the error
+                    return original_get_vehicle_status(token, vehicle, force_refresh)
+                except KeyError as err:
+                    # Log what we can access from the response
+                    _LOGGER.error(
+                        "KeyError in _get_vehicle_status: %s. "
+                        "This typically indicates Hyundai API returned an error response (rate limit/502). "
+                        "Enable hyundai_kia_connect_api debug logging to see full HTTP response.",
+                        err
+                    )
+                    raise
+
+            self.vehicle_manager.api._get_vehicle_status = logged_get_vehicle_status
         self.scan_interval: int = (
             config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL) * 60
         )
@@ -90,6 +112,18 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
             CONF_USE_EMAIL_WITH_GEOCODE_API, DEFAULT_USE_EMAIL_WITH_GEOCODE_API
         )
 
+        # Circuit breaker for API rate limiting
+        self._consecutive_failures = 0
+        self._failure_timestamps = []
+        self._degraded_mode = False
+        self._degraded_mode_until = None
+        self._last_successful_update = None
+
+        # Circuit breaker thresholds
+        self.MAX_CONSECUTIVE_FAILURES = 3
+        self.FAILURE_WINDOW_SECONDS = 300  # 5 minutes
+        self.DEGRADED_MODE_DURATION_SECONDS = 900  # 15 minutes
+
         super().__init__(
             hass,
             _LOGGER,
@@ -99,19 +133,127 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
             ),
         )
 
+    def _get_vehicle_identifiers(self) -> str:
+        """Get a string identifying the vehicles managed by this coordinator."""
+        if not self.vehicle_manager or not self.vehicle_manager.vehicles:
+            return "no vehicles"
+        vehicle_names = [v.name for v in self.vehicle_manager.vehicles.values()]
+        return ", ".join(vehicle_names)
+
+    def _check_circuit_breaker(self) -> bool:
+        """Check if circuit breaker should trip to degraded mode.
+
+        Returns True if we should skip API calls and use stale data.
+        """
+        now = dt_util.now()
+        vehicles = self._get_vehicle_identifiers()
+
+        # Check if we're already in degraded mode
+        if self._degraded_mode:
+            if self._degraded_mode_until and now < self._degraded_mode_until:
+                _LOGGER.warning(
+                    "Circuit breaker [%s]: In degraded mode until %s. Returning stale data.",
+                    vehicles,
+                    self._degraded_mode_until
+                )
+                return True
+            else:
+                # Cooldown expired, exit degraded mode
+                _LOGGER.info("Circuit breaker [%s]: Exiting degraded mode, will retry API", vehicles)
+                self._degraded_mode = False
+                self._degraded_mode_until = None
+                self._consecutive_failures = 0
+                self._failure_timestamps.clear()
+                return False
+
+        # Clean old failure timestamps outside the window
+        cutoff = now - timedelta(seconds=self.FAILURE_WINDOW_SECONDS)
+        self._failure_timestamps = [
+            ts for ts in self._failure_timestamps if ts > cutoff
+        ]
+
+        # Check if we should trip the circuit breaker
+        if self._consecutive_failures >= self.MAX_CONSECUTIVE_FAILURES:
+            if len(self._failure_timestamps) >= self.MAX_CONSECUTIVE_FAILURES:
+                # Trip circuit breaker
+                self._degraded_mode = True
+                self._degraded_mode_until = now + timedelta(
+                    seconds=self.DEGRADED_MODE_DURATION_SECONDS
+                )
+                _LOGGER.error(
+                    "Circuit breaker [%s]: Too many API failures (%d in %d seconds). "
+                    "Entering degraded mode until %s. Will return stale data.",
+                    vehicles,
+                    len(self._failure_timestamps),
+                    self.FAILURE_WINDOW_SECONDS,
+                    self._degraded_mode_until
+                )
+                return True
+
+        return False
+
+    def _record_api_failure(self):
+        """Record an API failure for circuit breaker tracking."""
+        now = dt_util.now()
+        self._consecutive_failures += 1
+        self._failure_timestamps.append(now)
+        vehicles = self._get_vehicle_identifiers()
+        _LOGGER.debug(
+            "Circuit breaker [%s]: Recorded failure #%d (total in window: %d)",
+            vehicles,
+            self._consecutive_failures,
+            len(self._failure_timestamps)
+        )
+
+    def _record_api_success(self):
+        """Record an API success, resetting failure counters."""
+        vehicles = self._get_vehicle_identifiers()
+        if self._consecutive_failures > 0:
+            _LOGGER.info(
+                "Circuit breaker [%s]: API success after %d failures, resetting counters",
+                vehicles,
+                self._consecutive_failures
+            )
+        self._consecutive_failures = 0
+        self._failure_timestamps.clear()
+        self._last_successful_update = dt_util.now()
+
+        # If we were in degraded mode, exit it early
+        if self._degraded_mode:
+            _LOGGER.info("Circuit breaker [%s]: API recovered, exiting degraded mode early", vehicles)
+            self._degraded_mode = False
+            self._degraded_mode_until = None
+
+    @property
+    def coordinator_health(self) -> str:
+        """Return health status: healthy, unhealthy, or degraded."""
+        if self._degraded_mode:
+            return "degraded"
+        elif self._consecutive_failures > 0:
+            return "unhealthy"
+        else:
+            return "healthy"
+
     async def _async_update_data(self):
         """Update data via library. Called by update_coordinator periodically.
 
         Allow to update for the first time without further checking
         Allow force update, if time diff between latest update and `now` is greater than force refresh delta
         """
+        # Check circuit breaker before attempting any API calls
+        if self._check_circuit_breaker():
+            return self.data  # Return stale data without hitting API
+
+        # Check authentication first (auth errors should still propagate)
         try:
             await self.async_check_and_refresh_token()
         except AuthenticationError as AuthError:
             raise ConfigEntryAuthFailed(AuthError) from AuthError
+
         current_hour = dt_util.now().hour
 
-        if (
+        # Determine if we should force refresh based on time window
+        should_force_refresh = (
             (self.no_force_refresh_hour_start <= self.no_force_refresh_hour_finish)
             and (
                 current_hour < self.no_force_refresh_hour_start
@@ -123,32 +265,44 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
                 current_hour < self.no_force_refresh_hour_start
                 and current_hour >= self.no_force_refresh_hour_finish
             )
-        ):
+        )
+
+        if should_force_refresh:
+            # Try force refresh
             try:
                 await self.hass.async_add_executor_job(
                     self.vehicle_manager.check_and_force_update_vehicles,
                     self.force_refresh_interval,
                 )
-            except Exception:
+                self._record_api_success()
+                return self.data
+            except Exception as ex:
+                # Catch EVERYTHING - never let UpdateFailed propagate
+                self._record_api_failure()
+                _LOGGER.error(
+                    "Force refresh failed with %s: %s. Falling back to cached data.",
+                    type(ex).__name__,
+                    str(ex)
+                )
+                # Try cached update as fallback
                 try:
-                    _LOGGER.exception(
-                        f"Force update failed, falling back to cached: {traceback.format_exc()}"
-                    )
                     await self.hass.async_add_executor_job(
                         self.vehicle_manager.update_all_vehicles_with_cached_state
                     )
-                except Exception:
-                    _LOGGER.exception(f"Cached update failed: {traceback.format_exc()}")
-                    raise UpdateFailed(
-                        f"Error communicating with API: {traceback.format_exc()}"
-                    )
-
+                except Exception as cached_ex:
+                    _LOGGER.error("Cached update also failed: %s", str(cached_ex))
+                return self.data  # Always return data, never raise UpdateFailed
         else:
-            await self.hass.async_add_executor_job(
-                self.vehicle_manager.update_all_vehicles_with_cached_state
-            )
-
-        return self.data
+            # Cached update path (during no-force-refresh hours)
+            try:
+                await self.hass.async_add_executor_job(
+                    self.vehicle_manager.update_all_vehicles_with_cached_state
+                )
+                self._record_api_success()
+            except Exception as ex:
+                self._record_api_failure()
+                _LOGGER.error("Cached update failed: %s", str(ex))
+            return self.data  # Always return data, never raise UpdateFailed
 
     async def async_update_all(self) -> None:
         """Update vehicle data."""

--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import timedelta
-import traceback
 import logging
 import asyncio
 
@@ -26,7 +25,7 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
 from .const import (
@@ -70,7 +69,9 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
         )
 
         # Monkey patch to log API responses before they cause KeyError
-        if hasattr(self.vehicle_manager, 'api') and hasattr(self.vehicle_manager.api, '_get_vehicle_status'):
+        if hasattr(self.vehicle_manager, "api") and hasattr(
+            self.vehicle_manager.api, "_get_vehicle_status"
+        ):
             original_get_vehicle_status = self.vehicle_manager.api._get_vehicle_status
 
             def logged_get_vehicle_status(token, vehicle, force_refresh):
@@ -85,7 +86,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
                         "KeyError in _get_vehicle_status: %s. "
                         "This typically indicates Hyundai API returned an error response (rate limit/502). "
                         "Enable hyundai_kia_connect_api debug logging to see full HTTP response.",
-                        err
+                        err,
                     )
                     raise
 
@@ -154,12 +155,15 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
                 _LOGGER.warning(
                     "Circuit breaker [%s]: In degraded mode until %s. Returning stale data.",
                     vehicles,
-                    self._degraded_mode_until
+                    self._degraded_mode_until,
                 )
                 return True
             else:
                 # Cooldown expired, exit degraded mode
-                _LOGGER.info("Circuit breaker [%s]: Exiting degraded mode, will retry API", vehicles)
+                _LOGGER.info(
+                    "Circuit breaker [%s]: Exiting degraded mode, will retry API",
+                    vehicles,
+                )
                 self._degraded_mode = False
                 self._degraded_mode_until = None
                 self._consecutive_failures = 0
@@ -186,7 +190,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
                     vehicles,
                     len(self._failure_timestamps),
                     self.FAILURE_WINDOW_SECONDS,
-                    self._degraded_mode_until
+                    self._degraded_mode_until,
                 )
                 return True
 
@@ -202,7 +206,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
             "Circuit breaker [%s]: Recorded failure #%d (total in window: %d)",
             vehicles,
             self._consecutive_failures,
-            len(self._failure_timestamps)
+            len(self._failure_timestamps),
         )
 
     def _record_api_success(self):
@@ -212,7 +216,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.info(
                 "Circuit breaker [%s]: API success after %d failures, resetting counters",
                 vehicles,
-                self._consecutive_failures
+                self._consecutive_failures,
             )
         self._consecutive_failures = 0
         self._failure_timestamps.clear()
@@ -220,7 +224,10 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
 
         # If we were in degraded mode, exit it early
         if self._degraded_mode:
-            _LOGGER.info("Circuit breaker [%s]: API recovered, exiting degraded mode early", vehicles)
+            _LOGGER.info(
+                "Circuit breaker [%s]: API recovered, exiting degraded mode early",
+                vehicles,
+            )
             self._degraded_mode = False
             self._degraded_mode_until = None
 
@@ -282,7 +289,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
                 _LOGGER.error(
                     "Force refresh failed with %s: %s. Falling back to cached data.",
                     type(ex).__name__,
-                    str(ex)
+                    str(ex),
                 )
                 # Try cached update as fallback
                 try:


### PR DESCRIPTION
Fixes issue where Genesis API goes into rate limit mode, then the plugin attempts to call the update method every minute indefinitely.

- Track consecutive failures with timestamps
- Enter degraded mode after 3 failures in 5 minutes
- 15-minute cooldown to let API recover
- Never raise UpdateFailed to prevent retry storms
- Always return stale data instead of crashing
- Automatic recovery when API responds
- Enhanced logging with vehicle identification