### PR TITLE
fix: convert heating to correct type

### DIFF
--- a/custom_components/kia_uvo/services.py
+++ b/custom_components/kia_uvo/services.py
@@ -87,6 +87,8 @@ def async_setup_services(hass: HomeAssistant) -> bool:
         steering_wheel = call.data.get("steering_wheel")
 
         # Confirm values are correct datatype
+        if heating is not None:
+            heating = int(heating)
         if front_left_seat is not None:
             front_left_seat = int(front_left_seat)
         if front_right_seat is not None:


### PR DESCRIPTION
Noticed I couldn't get the "Rear Defrost & Accessories" climate function enabled in requests on my 2025 EV6 in the USA, dug in a bit and found `heating` wasn't being converted properly to an `int` which meant these weren't matching: https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/blob/84bd2276e24ec97bd672d864c423d99808cb53fb/hyundai_kia_connect_api/KiaUvoApiUSA.py#L878-L879

Tested with this change and it works for me now 🎉 