### PR TITLE
fix: create EV charge limit entities for vehicles lacking cached targetSOC

### DIFF
--- a/custom_components/kia_uvo/number.py
+++ b/custom_components/kia_uvo/number.py
@@ -71,9 +71,7 @@ async def async_setup_entry(
             if description.key in (AC_CHARGING_LIMIT_KEY, DC_CHARGING_LIMIT_KEY):
                 if getattr(vehicle, "ev_battery_percentage", None) is not None:
                     entities.append(
-                        HyundaiKiaConnectNumber(
-                            coordinator, description, vehicle
-                        )
+                        HyundaiKiaConnectNumber(coordinator, description, vehicle)
                     )
             elif getattr(vehicle, description.key, None) is not None:
                 entities.append(


### PR DESCRIPTION


Some vehicles (e.g. 2020 Kia Niro EV on USA region) do not return targetSOC data from the cached state endpoint (cmm/gvi). Only the force refresh endpoint (rems/rvs) provides it. This means ev_charge_limits_ac and ev_charge_limits_dc are None at platform setup time, so the Number entities are never created.

Create charge limit entities for any vehicle that has EV data (ev_battery_percentage is not None), regardless of whether the charge limit values are populated yet. The entities will show as unavailable until the first force refresh populates them.

