### PR TITLE
feat: add reconfigure flow (re-auth or set PIN)

### DIFF
--- a/custom_components/kia_uvo/config_flow.py
+++ b/custom_components/kia_uvo/config_flow.py
@@ -15,6 +15,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.selector import selector
 from homeassistant.const import (
     CONF_PASSWORD,
     CONF_PIN,
@@ -65,6 +66,28 @@ STEP_REGION_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_REGION): vol.In(REGIONS),
         vol.Required(CONF_BRAND): vol.In(BRANDS),
+    }
+)
+
+STEP_RECONFIGURE_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required("reconfigure_choice"): selector(
+            {
+                "select": {
+                    "options": [
+                        {"value": "reauth", "label": "Re-authenticate your account"},
+                        {"value": "pin", "label": "Set / change PIN"},
+                    ],
+                    "mode": "list",
+                }
+            }
+        ),
+    }
+)
+
+STEP_PIN_ONLY_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_PIN): selector({"text": {"type": "password"}}),
     }
 )
 
@@ -155,6 +178,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._vehicle_manager: VehicleManager | None = None
         self._pending_login_data = None
         self._otp_request: OTPRequest | None = None
+        self._is_reconfigure = False
 
     @staticmethod
     @callback
@@ -211,7 +235,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     self._otp_request = result
 
                     return await self.async_step_select_otp_method()
-                if self.reauth_entry is None:
+                if self._is_reconfigure:
+                    return self.async_update_reload_and_abort(
+                        self._get_reconfigure_entry(),
+                        data_updates=full_config,
+                    )
+                elif self.reauth_entry is None:
                     title = f"{BRANDS[self._region_data[CONF_BRAND]]} {REGIONS[self._region_data[CONF_REGION]]} {user_input[CONF_USERNAME]}"
                     await self.async_set_unique_id(
                         hashlib.sha256(title.encode("utf-8")).hexdigest()
@@ -276,7 +305,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors=errors,
             )
         self._pending_login_data[CONF_TOKEN] = self._vehicle_manager.token.to_dict()
-        if self.reauth_entry is None:
+        if self._is_reconfigure:
+            return self.async_update_reload_and_abort(
+                self._get_reconfigure_entry(),
+                data_updates=self._pending_login_data,
+            )
+        elif self.reauth_entry is None:
             title = f"{BRANDS[self._pending_login_data[CONF_BRAND]]} {REGIONS[self._pending_login_data[CONF_REGION]]} {self._pending_login_data[CONF_USERNAME]}"
             await self.async_set_unique_id(
                 hashlib.sha256(title.encode("utf-8")).hexdigest()
@@ -316,7 +350,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
-                if self.reauth_entry is None:
+                if self._is_reconfigure:
+                    return self.async_update_reload_and_abort(
+                        self._get_reconfigure_entry(),
+                        data_updates=full_config,
+                    )
+                elif self.reauth_entry is None:
                     title = f"{BRANDS[self._region_data[CONF_BRAND]]} {REGIONS[self._region_data[CONF_REGION]]} {user_input[CONF_USERNAME]}"
                     await self.async_set_unique_id(
                         hashlib.sha256(title.encode("utf-8")).hexdigest()
@@ -336,6 +375,37 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="credentials_token",
             data_schema=STEP_CREDENTIALS_DATA_SCHEMA,
             errors=errors,
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Present choice: re-authenticate or set/change PIN."""
+        if user_input is not None:
+            if user_input["reconfigure_choice"] == "reauth":
+                self._is_reconfigure = True
+                return await self.async_step_user()
+            else:
+                return await self.async_step_reconfigure_pin()
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=STEP_RECONFIGURE_DATA_SCHEMA,
+        )
+
+    async def async_step_reconfigure_pin(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Allow the user to set or change the PIN without full re-authentication."""
+        if user_input is not None:
+            return self.async_update_reload_and_abort(
+                self._get_reconfigure_entry(),
+                data_updates={CONF_PIN: user_input[CONF_PIN]},
+            )
+
+        return self.async_show_form(
+            step_id="reconfigure_pin",
+            data_schema=STEP_PIN_ONLY_SCHEMA,
         )
 
     async def async_step_reauth(self, user_input=None):

--- a/custom_components/kia_uvo/strings.json
+++ b/custom_components/kia_uvo/strings.json
@@ -35,17 +35,35 @@
       "select_otp_method": {
         "title": "Select OTP Method",
         "description": "Your account requires verification. Choose how you want to receive your one‑time password.",
-        "data": { "method": "OTP delivery method" }
+        "data": {
+          "method": "OTP delivery method"
+        }
       },
       "enter_otp": {
         "title": "Enter One‑Time Password",
         "description": "Enter the verification code sent to your selected method.",
-        "data": { "otp": "One‑time password" }
+        "data": {
+          "otp": "One‑time password"
+        }
+      },
+      "reconfigure": {
+        "title": "Hyundai / Kia Connect - Reconfigure",
+        "data": {
+          "reconfigure_choice": "What would you like to do?"
+        }
+      },
+      "reconfigure_pin": {
+        "title": "Hyundai / Kia Connect - Set PIN",
+        "description": "Enter the PIN required to authorize remote commands (lock, unlock, climate) in the Kia/Hyundai Connect app.",
+        "data": {
+          "pin": "PIN"
+        }
       }
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "Reconfiguration was successful"
     },
     "error": {
       "invalid_auth": "[%key:component::hyundai_kia_connect::config::error::invalid_auth%]",

--- a/custom_components/kia_uvo/translations/da.json
+++ b/custom_components/kia_uvo/translations/da.json
@@ -16,10 +16,24 @@
       "reauth_confirm": {
         "title": "Hyundai / Kia Connect - Genbekræftelse",
         "description": "Din konto kan ikke godkendes. Klik på Indsend for at opsætte igen."
+      },
+      "reconfigure": {
+        "title": "Hyundai / Kia Connect - Genindstil",
+        "data": {
+          "reconfigure_choice": "Hvad vil du gøre?"
+        }
+      },
+      "reconfigure_pin": {
+        "title": "Hyundai / Kia Connect - Indstil PIN",
+        "description": "Indtast den PIN-kode, der kræves for at godkende fjernkommandoer (lås, oplås, klima) i Kia/Hyundai Connect-appen.",
+        "data": {
+          "pin": "PIN"
+        }
       }
     },
     "abort": {
-      "already_configured": "Enheden er allerede konfigureret"
+      "already_configured": "Enheden er allerede konfigureret",
+      "reconfigure_successful": "Genindstilling lykkedes"
     },
     "error": {
       "invalid_auth": "Login fejlede til Hyundai (Bluelink) / Kia (Uvo) Connect-servere. Brug den officielle app til at logge ud og logge ind igen, og prøv derefter igen!",

--- a/custom_components/kia_uvo/translations/de.json
+++ b/custom_components/kia_uvo/translations/de.json
@@ -16,10 +16,24 @@
       "reauth_confirm": {
         "title": "Hyundai / Kia Connect - Reauthentifizierung",
         "description": "Dein Konto kann nicht authentifiziert werden. Klicke auf Senden, um die Neukonfiguration durchzuführen."
+      },
+      "reconfigure": {
+        "title": "Hyundai / Kia Connect - Neu konfigurieren",
+        "data": {
+          "reconfigure_choice": "Was möchtest du tun?"
+        }
+      },
+      "reconfigure_pin": {
+        "title": "Hyundai / Kia Connect - PIN festlegen",
+        "description": "Gib die PIN ein, die für Fernbefehle (Sperren, Entsperren, Klimaanlage) in der Kia/Hyundai Connect App benötigt wird.",
+        "data": {
+          "pin": "PIN"
+        }
       }
     },
     "abort": {
-      "already_configured": "Dein Fahrzeug ist bereits konfiguriert"
+      "already_configured": "Dein Fahrzeug ist bereits konfiguriert",
+      "reconfigure_successful": "Neukonfiguration erfolgreich"
     },
     "error": {
       "invalid_auth": "Anmeldung bei Hyundai (Bluelink) / Kia (Uvo) Connect fehlgeschlagen. Bitte melde dich von deiner Hyundai/Kia-App ab, melde dich erneut an und versuche es erneut!",

--- a/custom_components/kia_uvo/translations/en.json
+++ b/custom_components/kia_uvo/translations/en.json
@@ -35,17 +35,35 @@
       "select_otp_method": {
         "title": "Select OTP Method",
         "description": "Your account requires verification. Choose how you want to receive your one‑time password.",
-        "data": { "method": "OTP delivery method" }
+        "data": {
+          "method": "OTP delivery method"
+        }
       },
       "enter_otp": {
         "title": "Enter One‑Time Password",
         "description": "Enter the verification code sent to your selected method.",
-        "data": { "otp": "One‑time password" }
+        "data": {
+          "otp": "One‑time password"
+        }
+      },
+      "reconfigure": {
+        "title": "Hyundai / Kia Connect - Reconfigure",
+        "data": {
+          "reconfigure_choice": "What would you like to do?"
+        }
+      },
+      "reconfigure_pin": {
+        "title": "Hyundai / Kia Connect - Set PIN",
+        "description": "Enter the PIN required to authorize remote commands (lock, unlock, climate) in the Kia/Hyundai Connect app.",
+        "data": {
+          "pin": "PIN"
+        }
       }
     },
     "abort": {
       "already_configured": "Device is already configured",
-      "reauth_successful": "Successfully reauthenticated"
+      "reauth_successful": "Successfully reauthenticated",
+      "reconfigure_successful": "Reconfiguration was successful"
     },
     "error": {
       "invalid_auth": "Login failed into Hyundai (Bluelink) / Kia (Uvo) Connect servers. Please use the official app to logout and log back in, then try again.",

--- a/custom_components/kia_uvo/translations/es.json
+++ b/custom_components/kia_uvo/translations/es.json
@@ -16,11 +16,25 @@
       "reauth_confirm": {
         "title": "Hyundai / Kia Connect - Reautenticación",
         "description": "Tu cuenta no puede autenticarse. Haz clic en Enviar para volver a configurar."
+      },
+      "reconfigure": {
+        "title": "Hyundai / Kia Connect - Reconfigurar",
+        "data": {
+          "reconfigure_choice": "¿Qué deseas hacer?"
+        }
+      },
+      "reconfigure_pin": {
+        "title": "Hyundai / Kia Connect - Establecer PIN",
+        "description": "Introduce el PIN necesario para autorizar comandos remotos (bloquear, desbloquear, climatización) en la app Kia/Hyundai Connect.",
+        "data": {
+          "pin": "PIN"
+        }
       }
     },
     "abort": {
       "already_configured": "El dispositivo ya está configurado",
-      "reauth_successful": "Reautenticación fue exitosa"
+      "reauth_successful": "Reautenticación fue exitosa",
+      "reconfigure_successful": "Reconfiguración exitosa"
     },
     "error": {
       "invalid_auth": "Falló el inicio de sesión en los servidores Hyundai (Bluelink) / Kia (Uvo) Connect. ¡Por favor, usa la aplicación oficial para cerrar sesión y volver a iniciarla e intenta de nuevo!",

--- a/custom_components/kia_uvo/translations/fi.json
+++ b/custom_components/kia_uvo/translations/fi.json
@@ -16,10 +16,24 @@
       "reauth_confirm": {
         "title": "Hyundai / Kia Connect - Uudelleentodennus",
         "description": "Tiliäsi ei voitu todentaa.  Napsauta lähetä yrittääksesi uudelleen."
+      },
+      "reconfigure": {
+        "title": "Hyundai / Kia Connect - Uudelleenmääritys",
+        "data": {
+          "reconfigure_choice": "Mitä haluat tehdä?"
+        }
+      },
+      "reconfigure_pin": {
+        "title": "Hyundai / Kia Connect - Aseta PIN",
+        "description": "Anna PIN-koodi, jota tarvitaan etäkomentojen (lukitus, avaus, ilmastointi) valtuuttamiseen Kia/Hyundai Connect -sovelluksessa.",
+        "data": {
+          "pin": "PIN"
+        }
       }
     },
     "abort": {
-      "already_configured": "Laite on jo määritetty"
+      "already_configured": "Laite on jo määritetty",
+      "reconfigure_successful": "Uudelleenmääritys onnistui"
     },
     "error": {
       "invalid_auth": "Kirjautuminen Hyundai (Bluelink) / Kia (Uvo) Connect -palvelimille epäonnistui. Kirjaudu virallisella sovelluksella ulos ja sisään ja yritä uudelleen!",

--- a/custom_components/kia_uvo/translations/fr.json
+++ b/custom_components/kia_uvo/translations/fr.json
@@ -16,10 +16,24 @@
       "reauth_confirm": {
         "title": "Hyundai / Kia Connect - Ré-authentification",
         "description": "Echec d'authentification. Clickez Soumettre pour recommencer la configuration."
+      },
+      "reconfigure": {
+        "title": "Hyundai / Kia Connect - Reconfigurer",
+        "data": {
+          "reconfigure_choice": "Que souhaitez-vous faire ?"
+        }
+      },
+      "reconfigure_pin": {
+        "title": "Hyundai / Kia Connect - Définir le PIN",
+        "description": "Entrez le PIN requis pour autoriser les commandes à distance (verrouillage, déverrouillage, climatisation) dans l'application Kia/Hyundai Connect.",
+        "data": {
+          "pin": "PIN"
+        }
       }
     },
     "abort": {
-      "already_configured": "Périférique déjà configuré"
+      "already_configured": "Périférique déjà configuré",
+      "reconfigure_successful": "Reconfiguration réussie"
     },
     "error": {
       "invalid_auth": "Authentification échouée aux serveurs Hyundai (Bluelink) / Kia (Uvo) Connect. Déconnectez-vous et reconnectez-vous sur l'application officielle puis ré-essayez!",

--- a/custom_components/kia_uvo/translations/hu.json
+++ b/custom_components/kia_uvo/translations/hu.json
@@ -16,10 +16,24 @@
       "reauth_confirm": {
         "title": "Hyundai / Kia Connect - Újra hitelesítés",
         "description": "Fiókja nem hitelesíthető. Az újra beállításhoz kattintson a Küldés gombra."
+      },
+      "reconfigure": {
+        "title": "Hyundai / Kia Connect - Újrakonfigurálás",
+        "data": {
+          "reconfigure_choice": "Mit szeretnél tenni?"
+        }
+      },
+      "reconfigure_pin": {
+        "title": "Hyundai / Kia Connect - PIN beállítása",
+        "description": "Add meg a PIN-kódot, amely szükséges a távirányítási parancsok (zárás, nyitás, légkondicionálás) engedélyezéséhez a Kia/Hyundai Connect alkalmazásban.",
+        "data": {
+          "pin": "PIN"
+        }
       }
     },
     "abort": {
-      "already_configured": "Az eszköz már konfigurálva van"
+      "already_configured": "Az eszköz már konfigurálva van",
+      "reconfigure_successful": "Újrakonfigurálás sikeres"
     },
     "error": {
       "invalid_auth": "Nem sikerült bejelentkezni a Hyundai (Bluelink) / Kia (Uvo) Connect szerverekre. Kérjük, használja a hivatalos alkalmazást a kijelentkezéshez és a bejelentkezéshez, majd próbálja újra!",

--- a/custom_components/kia_uvo/translations/it.json
+++ b/custom_components/kia_uvo/translations/it.json
@@ -16,10 +16,24 @@
       "reauth_confirm": {
         "title": "Hyundai / Kia Connect - Riautenticazione",
         "description": "Il tuo account non può essere autenticato. Fai clic su Invia per configurarlo di nuovo."
+      },
+      "reconfigure": {
+        "title": "Hyundai / Kia Connect - Riconfigura",
+        "data": {
+          "reconfigure_choice": "Cosa vuoi fare?"
+        }
+      },
+      "reconfigure_pin": {
+        "title": "Hyundai / Kia Connect - Imposta PIN",
+        "description": "Inserisci il PIN necessario per autorizzare i comandi remoti (blocco, sblocco, climatizzazione) nell'app Kia/Hyundai Connect.",
+        "data": {
+          "pin": "PIN"
+        }
       }
     },
     "abort": {
-      "already_configured": "Il dispositivo è già configurato"
+      "already_configured": "Il dispositivo è già configurato",
+      "reconfigure_successful": "Riconfigurazione riuscita"
     },
     "error": {
       "invalid_auth": "Impossibile effettuare il login nei server Hyundai (Bluelink) / Kia (Uvo) Connect. Utilizza l'app ufficiale per effettuare il logout, accedere nuovamente e riprovare!",

--- a/custom_components/kia_uvo/translations/nb.json
+++ b/custom_components/kia_uvo/translations/nb.json
@@ -16,10 +16,24 @@
       "reauth_confirm": {
         "title": "Hyundai / Kia Connect - Reautentisering",
         "description": "Kontoen din kan ikke autentiseres. Klikk Send for å sette opp på nytt."
+      },
+      "reconfigure": {
+        "title": "Hyundai / Kia Connect - Rekonfigurer",
+        "data": {
+          "reconfigure_choice": "Hva vil du gjøre?"
+        }
+      },
+      "reconfigure_pin": {
+        "title": "Hyundai / Kia Connect - Angi PIN",
+        "description": "Skriv inn PIN-koden som kreves for å autorisere fjernkommandoer (lås, lås opp, klimaanlegg) i Kia/Hyundai Connect-appen.",
+        "data": {
+          "pin": "PIN"
+        }
       }
     },
     "abort": {
-      "already_configured": "Enheten er allerede konfigurert"
+      "already_configured": "Enheten er allerede konfigurert",
+      "reconfigure_successful": "Rekonfigurering vellykket"
     },
     "error": {
       "invalid_auth": "Innlogging mislyktes til Hyundai (Bluelink) / Kia (Uvo) Connect-servere. Vennligst bruk den offisielle appen for å logge ut og logg inn igjen, og prøv på nytt!",

--- a/custom_components/kia_uvo/translations/nl.json
+++ b/custom_components/kia_uvo/translations/nl.json
@@ -16,10 +16,24 @@
       "reauth_confirm": {
         "title": "Hyundai / Kia Connect - Opnieuw Authenticeren",
         "description": "Uw account kan zich niet authenticeren. Klik Submit om het opnieuw te proberen."
+      },
+      "reconfigure": {
+        "title": "Hyundai / Kia Connect - Opnieuw configureren",
+        "data": {
+          "reconfigure_choice": "Wat wil je doen?"
+        }
+      },
+      "reconfigure_pin": {
+        "title": "Hyundai / Kia Connect - PIN instellen",
+        "description": "Voer de PIN in die vereist is om externe opdrachten (vergrendelen, ontgrendelen, klimaatbeheersing) te autoriseren in de Kia/Hyundai Connect-app.",
+        "data": {
+          "pin": "PIN"
+        }
       }
     },
     "abort": {
-      "already_configured": "Het device is al geconfigureerd"
+      "already_configured": "Het device is al geconfigureerd",
+      "reconfigure_successful": "Herconfiguratie geslaagd"
     },
     "error": {
       "invalid_auth": "Het authenticeren op de Hyundai (Bluelink) / Kia (Uvo) Connect servers is niet gelukt. Gebruik svp de officiële app om uit te loggen en weer in te loggen, en probeer het dan opnieuw!",

--- a/custom_components/kia_uvo/translations/sv.json
+++ b/custom_components/kia_uvo/translations/sv.json
@@ -16,10 +16,24 @@
       "reauth_confirm": {
         "title": "Hyundai / Kia Connect - Reautentisering",
         "description": "Kontot kan inte autentiseres. Klicka på Send för att sätta upp på nytt."
+      },
+      "reconfigure": {
+        "title": "Hyundai / Kia Connect - Konfigurera om",
+        "data": {
+          "reconfigure_choice": "Vad vill du göra?"
+        }
+      },
+      "reconfigure_pin": {
+        "title": "Hyundai / Kia Connect - Ange PIN",
+        "description": "Ange PIN-koden som krävs för att auktorisera fjärrkommandon (lås, lås upp, klimat) i Kia/Hyundai Connect-appen.",
+        "data": {
+          "pin": "PIN"
+        }
       }
     },
     "abort": {
-      "already_configured": "Enheten är redan konfigurerad"
+      "already_configured": "Enheten är redan konfigurerad",
+      "reconfigure_successful": "Omkonfigurering lyckades"
     },
     "error": {
       "invalid_auth": "Innloggningen misslyckades till Hyundai (Bluelink) / Kia (Uvo) Connect-servern. Använd denofficiella appen för att logga ut och logga in igen, och prova igen!",

--- a/custom_components/kia_uvo/translations/zh-Hans.json
+++ b/custom_components/kia_uvo/translations/zh-Hans.json
@@ -16,10 +16,24 @@
       "reauth_confirm": {
         "title": "Hyundai / Kia Connect - 重新登录账号",
         "description": "您的账户验证失败。点击提交重新登录授权。"
+      },
+      "reconfigure": {
+        "title": "Hyundai / Kia Connect - 重新配置",
+        "data": {
+          "reconfigure_choice": "您想做什么？"
+        }
+      },
+      "reconfigure_pin": {
+        "title": "Hyundai / Kia Connect - 设置 PIN",
+        "description": "请输入在 Kia/Hyundai Connect 应用中授权远程命令（锁车、解锁、空调）所需的 PIN 码。",
+        "data": {
+          "pin": "PIN"
+        }
       }
     },
     "abort": {
-      "already_configured": "设备已配置"
+      "already_configured": "设备已配置",
+      "reconfigure_successful": "重新配置成功"
     },
     "error": {
       "invalid_auth": "连接服务器失败。请使用官方应用程序注销并重新登录，然后重试！",


### PR DESCRIPTION
Adds a reconfigure option to the integration (`Settings -> Integrations -> Kia Uvo / Hyundai Bluelink -> 3dot menu -> Reconfigure`) with two choices:

- `Re-authenticate your account`: full login flow and updates the existing credentials
- `Set / change PIN`: password-type input to set/update the PIN required for remote commands (lock/unlock/climate), without requiring full re-authentication

**Disclaimer**: Inspiration has been taken from https://github.com/andreadegiovine/homeassistant-stellantis-vehicles, since the Reconfigure option there saved me a few times already, and manually hacking the pin into `.storage/core.config_entries` just because it might've been forgotten on first log-in is potentially error prone.

**Disclaimer No.2**: AI has been used to provide the translations.