### PR TITLE
fix: validate both charge limits before sending API call

### DIFF
--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -213,6 +213,11 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
         Used after setting charge limits because the soft refresh (cmm/gvi)
         does not return targetSOC for some vehicles. A force refresh (rems/rvs)
         ensures the fresh charge limits are read back immediately.
+
+        Uses async_set_updated_data instead of async_refresh to avoid a
+        redundant cmm/gvi API call — the force refresh already updates the
+        vehicle objects in-place (rems/rvs + cmm/gvi), so we just need to
+        notify HA entities to re-read their state.
         """
         try:
             await asyncio.sleep(5)
@@ -224,10 +229,15 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
                 60,
             )
         finally:
-            await self.hass.async_add_executor_job(
-                self.vehicle_manager.force_refresh_vehicle_state, vehicle_id
-            )
-            await self.async_refresh()
+            try:
+                await self.hass.async_add_executor_job(
+                    self.vehicle_manager.force_refresh_vehicle_state, vehicle_id
+                )
+            except Exception:
+                _LOGGER.exception(
+                    "Force refresh after setting charge limits failed"
+                )
+            self.async_set_updated_data(self.data)
 
     async def async_lock_vehicle(self, vehicle_id: str):
         await self.async_check_and_refresh_token()

--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -207,6 +207,28 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
         finally:
             await self.async_refresh()
 
+    async def async_await_action_and_force_refresh(self, vehicle_id, action_id):
+        """Wait for action then force refresh to get fresh vehicle data.
+
+        Used after setting charge limits because the soft refresh (cmm/gvi)
+        does not return targetSOC for some vehicles. A force refresh (rems/rvs)
+        ensures the fresh charge limits are read back immediately.
+        """
+        try:
+            await asyncio.sleep(5)
+            await self.hass.async_add_executor_job(
+                self.vehicle_manager.check_action_status,
+                vehicle_id,
+                action_id,
+                True,
+                60,
+            )
+        finally:
+            await self.hass.async_add_executor_job(
+                self.vehicle_manager.force_refresh_vehicle_state, vehicle_id
+            )
+            await self.async_refresh()
+
     async def async_lock_vehicle(self, vehicle_id: str):
         await self.async_check_and_refresh_token()
         try:
@@ -314,7 +336,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
         except Exception as err:
             raise HomeAssistantError(f"Failed to set charge limits: {err}") from err
         self.hass.async_create_task(
-            self.async_await_action_and_refresh(vehicle_id, action_id)
+            self.async_await_action_and_force_refresh(vehicle_id, action_id)
         )
 
     async def async_set_charging_current(self, vehicle_id: str, level: int):

--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -234,9 +234,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
                     self.vehicle_manager.force_refresh_vehicle_state, vehicle_id
                 )
             except Exception:
-                _LOGGER.exception(
-                    "Force refresh after setting charge limits failed"
-                )
+                _LOGGER.exception("Force refresh after setting charge limits failed")
             self.async_set_updated_data(self.data)
 
     async def async_lock_vehicle(self, vehicle_id: str):

--- a/custom_components/kia_uvo/number.py
+++ b/custom_components/kia_uvo/number.py
@@ -15,6 +15,7 @@ from homeassistant.components.number import (
 from homeassistant.const import PERCENTAGE
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN, DYNAMIC_UNIT
@@ -106,12 +107,13 @@ class HyundaiKiaConnectNumber(NumberEntity, HyundaiKiaConnectEntity):
         """Return the entity value to represent the entity state."""
         return getattr(self.vehicle, self._key)
 
+    @staticmethod
+    def _is_valid_charge_limit(val) -> bool:
+        """Check if a charge limit value is a valid integer 50-100 in steps of 10."""
+        return isinstance(val, (int, float)) and int(val) in range(50, 101, 10)
+
     async def async_set_native_value(self, value: float) -> None:
         """Set new charging limit."""
-        # force refresh of state so that we can get the value for the other charging limit
-        # since we have to set both limits as compound API call.
-        # await self.coordinator.async_force_update_all()
-
         if (
             self._description.key == AC_CHARGING_LIMIT_KEY
             and self.vehicle.ev_charge_limits_ac == int(value)
@@ -125,13 +127,37 @@ class HyundaiKiaConnectNumber(NumberEntity, HyundaiKiaConnectEntity):
 
         # set new limits
         if self._description.key == AC_CHARGING_LIMIT_KEY:
-            ac = value
+            ac = int(value)
             dc = self.vehicle.ev_charge_limits_dc
-            await self.coordinator.async_set_charge_limits(self.vehicle.id, ac, dc)
+            if not self._is_valid_charge_limit(dc):
+                _LOGGER.error(
+                    "Cannot set charge limit: the DC charging limit is not "
+                    "available yet (%r). Try performing a force refresh first, "
+                    "or set the DC slider to a valid value (50-100%%).",
+                    dc,
+                )
+                raise HomeAssistantError(
+                    "Cannot set charge limit: the DC charging limit "
+                    "is not available yet. Try performing a force refresh "
+                    "first, or set the DC slider to a valid value (50-100%)."
+                )
+            await self.coordinator.async_set_charge_limits(self.vehicle.id, ac, int(dc))
         elif self._description.key == DC_CHARGING_LIMIT_KEY:
             ac = self.vehicle.ev_charge_limits_ac
-            dc = value
-            await self.coordinator.async_set_charge_limits(self.vehicle.id, ac, dc)
+            dc = int(value)
+            if not self._is_valid_charge_limit(ac):
+                _LOGGER.error(
+                    "Cannot set charge limit: the AC charging limit is not "
+                    "available yet (%r). Try performing a force refresh first, "
+                    "or set the AC slider to a valid value (50-100%%).",
+                    ac,
+                )
+                raise HomeAssistantError(
+                    "Cannot set charge limit: the AC charging limit "
+                    "is not available yet. Try performing a force refresh "
+                    "first, or set the AC slider to a valid value (50-100%)."
+                )
+            await self.coordinator.async_set_charge_limits(self.vehicle.id, int(ac), dc)
         elif self._description.key == V2L_LIMIT_KEY:
             v2l = value
             await self.coordinator.async_set_v2l_limit(self.vehicle.id, v2l)


### PR DESCRIPTION
Closes #1569

## Summary

Fixes charge limit sliders sending invalid values and snapping back to stale data after being set.

**Root cause:** The Kia API requires both AC and DC charge limits in a single compound call. When a user moves one slider, the integration reads the "other" cached value from the vehicle object. If that value is `None` (e.g. before a force refresh has been performed), the API silently ignores the request. Additionally, after setting charge limits, the soft refresh (cmm/gvi) does not return `targetSOC` for some vehicles, causing sliders to snap back to stale values.

### Changes

**number.py — Validate before sending:**
- Added `_is_valid_charge_limit()` to check the cached "other" charge limit is a valid integer 50-100 in steps of 10
- If invalid, raises `HomeAssistantError` with a user-friendly message telling them to force refresh first or set the other slider manually
- V2L code is completely untouched

**coordinator.py — Force refresh after setting:**
- Added `async_await_action_and_force_refresh()` method that does a force refresh (rems/rvs) instead of soft refresh (cmm/gvi) after the action completes
- Force refresh is wrapped in `try/except` so a failed refresh still notifies HA entities to update (prevents entities from being stuck in stale state)
- Uses `async_set_updated_data()` instead of `async_refresh()` to avoid a redundant cmm/gvi API call — the force refresh already updates vehicle objects in-place, so we just notify HA to re-read state
- `async_set_charge_limits()` now uses the new method so fresh charge limit values are read back immediately
- Prevents slider snap-back on vehicles where cmm/gvi doesn't return targetSOC (e.g. 2020 Kia Niro EV)

### Companion PR

> **API side:** https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/pull/1059
> Fixes force refresh to always update targetSOC with fresh data, adds robust parsing and 18 unit tests.
>
> **⚠️ Merge order: PR #1059 (API) must be merged FIRST**, then this PR (#1568).

## Test plan

- [x] Manual test: moving AC slider when DC is unknown shows error toast in HA UI
- [x] Manual test: after force refresh, both sliders show correct values and can be set
- [x] Manual test: after setting a charge limit, slider reflects new value within ~60 seconds (force refresh reads it back)
- [ ] Verify V2L slider (if present) still works normally
- [x] Verify no regression for other vehicle commands (lock, unlock, climate, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)