### PR TITLE
fix: EV entity discovery when initial EV fields are null

### DIFF
--- a/custom_components/kia_uvo/binary_sensor.py
+++ b/custom_components/kia_uvo/binary_sensor.py
@@ -40,7 +40,7 @@ def _is_electrified_vehicle(vehicle: Vehicle) -> bool:
 
 
 def _should_add_binary_sensor(
-    description: "HyundaiKiaBinarySensorEntityDescription", vehicle: Vehicle
+    description: HyundaiKiaBinarySensorEntityDescription, vehicle: Vehicle
 ) -> bool:
     """Create EV entities even when the backend currently reports null values."""
     if getattr(vehicle, description.key, None) is not None:
@@ -199,7 +199,9 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
     HyundaiKiaBinarySensorEntityDescription(
         key="ev_battery_is_plugged_in",
         name="EV Battery Plug",
-        is_on=lambda vehicle: _normalize_optional_bool(vehicle.ev_battery_is_plugged_in),
+        is_on=lambda vehicle: _normalize_optional_bool(
+            vehicle.ev_battery_is_plugged_in
+        ),
         device_class=BinarySensorDeviceClass.PLUG,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),

--- a/custom_components/kia_uvo/binary_sensor.py
+++ b/custom_components/kia_uvo/binary_sensor.py
@@ -9,6 +9,7 @@ from typing import Final
 
 from homeassistant.const import EntityCategory
 from hyundai_kia_connect_api import Vehicle
+from hyundai_kia_connect_api.const import ENGINE_TYPES
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -24,6 +25,28 @@ from .coordinator import HyundaiKiaConnectDataUpdateCoordinator
 from .entity import HyundaiKiaConnectEntity
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _normalize_optional_bool(value: object) -> bool | None:
+    """Normalize 0/1 backend flags to booleans while preserving None."""
+    if value is None:
+        return None
+    return bool(value)
+
+
+def _is_electrified_vehicle(vehicle: Vehicle) -> bool:
+    """Return True for EV and PHEV vehicles."""
+    return getattr(vehicle, "engine_type", None) in (ENGINE_TYPES.EV, ENGINE_TYPES.PHEV)
+
+
+def _should_add_binary_sensor(
+    description: "HyundaiKiaBinarySensorEntityDescription", vehicle: Vehicle
+) -> bool:
+    """Create EV entities even when the backend currently reports null values."""
+    if getattr(vehicle, description.key, None) is not None:
+        return True
+
+    return _is_electrified_vehicle(vehicle) and description.key.startswith("ev_")
 
 
 @dataclass
@@ -169,14 +192,14 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
     HyundaiKiaBinarySensorEntityDescription(
         key="ev_battery_is_charging",
         name="EV Battery Charge",
-        is_on=lambda vehicle: vehicle.ev_battery_is_charging,
+        is_on=lambda vehicle: _normalize_optional_bool(vehicle.ev_battery_is_charging),
         device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     HyundaiKiaBinarySensorEntityDescription(
         key="ev_battery_is_plugged_in",
         name="EV Battery Plug",
-        is_on=lambda vehicle: vehicle.ev_battery_is_plugged_in,
+        is_on=lambda vehicle: _normalize_optional_bool(vehicle.ev_battery_is_plugged_in),
         device_class=BinarySensorDeviceClass.PLUG,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
@@ -466,7 +489,7 @@ async def async_setup_entry(
     for vehicle_id in coordinator.vehicle_manager.vehicles.keys():
         vehicle: Vehicle = coordinator.vehicle_manager.vehicles[vehicle_id]
         for description in SENSOR_DESCRIPTIONS:
-            if getattr(vehicle, description.key, None) is not None:
+            if _should_add_binary_sensor(description, vehicle):
                 entities.append(
                     HyundaiKiaConnectBinarySensor(coordinator, description, vehicle)
                 )

--- a/custom_components/kia_uvo/number.py
+++ b/custom_components/kia_uvo/number.py
@@ -6,6 +6,7 @@ import logging
 from typing import Final
 
 from hyundai_kia_connect_api import Vehicle
+from hyundai_kia_connect_api.const import ENGINE_TYPES
 
 from homeassistant.components.number import (
     NumberEntity,
@@ -26,6 +27,11 @@ _LOGGER = logging.getLogger(__name__)
 AC_CHARGING_LIMIT_KEY = "ev_charge_limits_ac"
 DC_CHARGING_LIMIT_KEY = "ev_charge_limits_dc"
 V2L_LIMIT_KEY = "ev_v2l_discharge_limit"
+
+
+def _is_electrified_vehicle(vehicle: Vehicle) -> bool:
+    """Return True for EV and PHEV vehicles."""
+    return getattr(vehicle, "engine_type", None) in (ENGINE_TYPES.EV, ENGINE_TYPES.PHEV)
 
 NUMBER_DESCRIPTIONS: Final[tuple[NumberEntityDescription, ...]] = (
     NumberEntityDescription(
@@ -69,7 +75,7 @@ async def async_setup_entry(
         vehicle: Vehicle = coordinator.vehicle_manager.vehicles[vehicle_id]
         for description in NUMBER_DESCRIPTIONS:
             if description.key in (AC_CHARGING_LIMIT_KEY, DC_CHARGING_LIMIT_KEY):
-                if getattr(vehicle, "ev_battery_percentage", None) is not None:
+                if getattr(vehicle, description.key, None) is not None or _is_electrified_vehicle(vehicle):
                     entities.append(
                         HyundaiKiaConnectNumber(coordinator, description, vehicle)
                     )

--- a/custom_components/kia_uvo/number.py
+++ b/custom_components/kia_uvo/number.py
@@ -33,6 +33,7 @@ def _is_electrified_vehicle(vehicle: Vehicle) -> bool:
     """Return True for EV and PHEV vehicles."""
     return getattr(vehicle, "engine_type", None) in (ENGINE_TYPES.EV, ENGINE_TYPES.PHEV)
 
+
 NUMBER_DESCRIPTIONS: Final[tuple[NumberEntityDescription, ...]] = (
     NumberEntityDescription(
         key=AC_CHARGING_LIMIT_KEY,
@@ -75,7 +76,9 @@ async def async_setup_entry(
         vehicle: Vehicle = coordinator.vehicle_manager.vehicles[vehicle_id]
         for description in NUMBER_DESCRIPTIONS:
             if description.key in (AC_CHARGING_LIMIT_KEY, DC_CHARGING_LIMIT_KEY):
-                if getattr(vehicle, description.key, None) is not None or _is_electrified_vehicle(vehicle):
+                if getattr(
+                    vehicle, description.key, None
+                ) is not None or _is_electrified_vehicle(vehicle):
                     entities.append(
                         HyundaiKiaConnectNumber(coordinator, description, vehicle)
                     )

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -43,7 +43,10 @@ def _should_add_sensor(description: SensorEntityDescription, vehicle: Vehicle) -
     if getattr(vehicle, description.key, None) is not None:
         return True
 
-    return _is_electrified_vehicle(vehicle) and description.key.startswith(("ev_", "_ev_"))
+    return _is_electrified_vehicle(vehicle) and description.key.startswith(
+        ("ev_", "_ev_")
+    )
+
 
 SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
     SensorEntityDescription(

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -7,6 +7,7 @@ from typing import Final
 from datetime import date
 
 from hyundai_kia_connect_api import Vehicle
+from hyundai_kia_connect_api.const import ENGINE_TYPES
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -30,6 +31,19 @@ from .const import CHARGING_CURRENTS, DOMAIN, DYNAMIC_UNIT
 from .entity import HyundaiKiaConnectEntity
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _is_electrified_vehicle(vehicle: Vehicle) -> bool:
+    """Return True for EV and PHEV vehicles."""
+    return getattr(vehicle, "engine_type", None) in (ENGINE_TYPES.EV, ENGINE_TYPES.PHEV)
+
+
+def _should_add_sensor(description: SensorEntityDescription, vehicle: Vehicle) -> bool:
+    """Create EV entities even when the backend currently reports null values."""
+    if getattr(vehicle, description.key, None) is not None:
+        return True
+
+    return _is_electrified_vehicle(vehicle) and description.key.startswith(("ev_", "_ev_"))
 
 SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
     SensorEntityDescription(
@@ -286,7 +300,7 @@ async def async_setup_entry(
     for vehicle_id in coordinator.vehicle_manager.vehicles.keys():
         vehicle: Vehicle = coordinator.vehicle_manager.vehicles[vehicle_id]
         for description in SENSOR_DESCRIPTIONS:
-            if getattr(vehicle, description.key, None) is not None:
+            if _should_add_sensor(description, vehicle):
                 entities.append(
                     HyundaiKiaConnectSensor(coordinator, description, vehicle)
                 )


### PR DESCRIPTION
## Summary

This fixes a discovery issue for EV/PHEV vehicles where EV-related entities can be skipped permanently if the backend returns `null` EV fields during initial setup.

## Problem

Entity creation currently depends on values already being present:

- `sensor.py` only creates entities when `getattr(vehicle, description.key, None) is not None`
- `binary_sensor.py` does the same for EV binary sensors
- `number.py` only creates AC/DC charging limit entities when `ev_battery_percentage` is present

For at least some Kia Canada EV vehicles, the backend may initially omit or null out `status.evStatus.*`. When that happens, EV entities are never created, even if valid EV data appears on a later refresh.

## Fix

- Create EV/PHEV sensor entities based on `vehicle.engine_type`, even when the current EV value is `None`
- Create EV/PHEV binary sensors the same way
- Create AC/DC charge limit numbers for electrified vehicles even if `ev_battery_percentage` is missing
- Normalize `0/1` backend flags for EV charging / plugged-in binary sensors to proper booleans

## Validation

Tested locally with a Kia EV6 in Canada.

Before the patch, EV charge-related entities were missing. After reloading the integration with this patch, the EV entities were created and the values matched the Kia app.
