### PR TITLE
fix: bump hyundai_kia_connect_api from 4.7.2 to 4.8.2

### DIFF
--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Hyundai-Kia-Connect/kia_uvo/issues",
   "loggers": ["kia_uvo", "hyundai_kia_connect_api"],
-  "requirements": ["hyundai_kia_connect_api==4.7.2"],
+  "requirements": ["hyundai_kia_connect_api==4.8.2"],
   "version": "2.52.1"
 }


### PR DESCRIPTION
## Summary
- Bumps `hyundai_kia_connect_api` from `==4.7.2` to `==4.8.2`, catching up on 4 releases

## Changes included (4.7.3 → 4.8.2)
- **4.7.3**: fix(usa): force refresh should always update targetSOC charge limits (Hyundai-Kia-Connect/hyundai_kia_connect_api#1059)
- **4.8.0**: fix(AU): stale location for CCS2 cars (Hyundai-Kia-Connect/hyundai_kia_connect_api#1064), fix(CA): get_location error 6459 (Hyundai-Kia-Connect/hyundai_kia_connect_api#1069), feat: KiaHyundaiToken browser-based token tool (Hyundai-Kia-Connect/hyundai_kia_connect_api#1067)
- **4.8.1**: fix(EU): correct OAuth endpoint/headers for Genesis EU (Hyundai-Kia-Connect/hyundai_kia_connect_api#1066)
- **4.8.2**: fix(CA): skip timezone detection for fresh UTC timestamps (Hyundai-Kia-Connect/hyundai_kia_connect_api#1071), fix: no debug logging of tokens (Hyundai-Kia-Connect/hyundai_kia_connect_api#1078)