### PR TITLE
chore: add Renovate config for automated dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:best-practices"]
+}


### PR DESCRIPTION
## Summary

Adds `renovate.json` so that dependency version bumps (e.g. `hyundai_kia_connect_api` in `manifest.json`) get automatic PRs when new versions are published on PyPI.

Currently these bumps are done manually, which means the integration can fall several API versions behind (e.g. #1593 bumped from 4.7.2 to 4.8.2 after a month-long gap). Renovate's built-in [`homeassistant-manifest` manager](https://docs.renovatebot.com/modules/manager/homeassistant-manifest/) (shipped in Renovate 43.69.0) natively understands the `requirements` array in `manifest.json` and checks PyPI for updates.

## Setup steps (maintainer action required)

This config file is inert on its own — the [Renovate GitHub App](https://github.com/apps/renovate) needs to be installed on this repo for it to work.

**Order of operations:**

1. **Merge this PR** — adds the config file to the repo
2. **Install the Renovate GitHub App** — go to https://github.com/apps/renovate, click "Install", and select the `Hyundai-Kia-Connect/kia_uvo` repository
3. **Done** — Renovate will start scanning the repo and open PRs automatically when dependencies have new versions

After installation, Renovate will open an initial "Configure Renovate" PR (their onboarding PR) which you can merge or close. After that, it will open individual PRs for each dependency update as they're published.

## What it does

- Watches `manifest.json` for pinned dependencies (`package==version`)
- When a new version appears on PyPI, opens a PR to bump the pin
- Uses Renovate's `config:best-practices` preset (sensible defaults for grouping, automerge policies, etc.)
- Does **not** auto-merge — all PRs require manual review and merge

## What it doesn't do

- No changes to CI/CD or existing workflows
- No new secrets or tokens required (the Renovate App uses its own authentication)
- Does not affect the semantic-release workflow that bumps the integration version