### PR TITLE
fix: Entity naming for Home Assistant 2026.4+ 

### DIFF
--- a/custom_components/kia_uvo/binary_sensor.py
+++ b/custom_components/kia_uvo/binary_sensor.py
@@ -490,7 +490,7 @@ class HyundaiKiaConnectBinarySensor(BinarySensorEntity, HyundaiKiaConnectEntity)
         super().__init__(coordinator, vehicle)
         self.entity_description: HyundaiKiaBinarySensorEntityDescription = description
         self._attr_unique_id = f"{DOMAIN}_{vehicle.id}_{description.key}"
-        self._attr_name = f"{vehicle.name} {description.name}"
+        self._attr_name = description.name
         if description.entity_category:
             self._attr_entity_category = description.entity_category
 

--- a/custom_components/kia_uvo/climate.py
+++ b/custom_components/kia_uvo/climate.py
@@ -90,7 +90,7 @@ class HyundaiKiaCarClimateControlSwitch(HyundaiKiaConnectEntity, ClimateEntity):
         )
         self.vehicle_manager = coordinator.vehicle_manager
         self._attr_unique_id = f"{DOMAIN}_{vehicle.id}_climate_control"
-        self._attr_name = f"{vehicle.name} Climate Control"
+        self._attr_name = self.entity_description.name
 
         # set the Climate Request to the current actual state of the car
         self.climate_config = ClimateRequestOptions(

--- a/custom_components/kia_uvo/device_tracker.py
+++ b/custom_components/kia_uvo/device_tracker.py
@@ -46,7 +46,7 @@ class HyundaiKiaConnectTracker(TrackerEntity, HyundaiKiaConnectEntity):
     ):
         HyundaiKiaConnectEntity.__init__(self, coordinator, vehicle)
         self._attr_unique_id = f"{DOMAIN}_{vehicle.id}_location"
-        self._attr_name = f"{vehicle.name} Location"
+        self._attr_name = "Location"
         self._attr_icon = "mdi:map-marker-outline"
 
     @property

--- a/custom_components/kia_uvo/entity.py
+++ b/custom_components/kia_uvo/entity.py
@@ -9,6 +9,8 @@ from .const import BRANDS, DOMAIN, REGIONS
 class HyundaiKiaConnectEntity(CoordinatorEntity):
     """Class for base entity for Hyundai / Kia Connect integration."""
 
+    _attr_has_entity_name = True
+
     def __init__(self, coordinator, vehicle):
         """Initialize the base entity."""
         super().__init__(coordinator)
@@ -20,7 +22,7 @@ class HyundaiKiaConnectEntity(CoordinatorEntity):
         return DeviceInfo(
             identifiers={(DOMAIN, self.vehicle.id)},
             manufacturer=f"{BRANDS[self.coordinator.vehicle_manager.brand]} {REGIONS[self.coordinator.vehicle_manager.region]}",
-            model=f"{self.vehicle.name} ({self.vehicle.model})",
-            name=f"{self.vehicle.name} ({self.vehicle.model})",
+            model=self.vehicle.model,
+            name=self.vehicle.name,
             serial_number=f"{self.vehicle.VIN}",
         )

--- a/custom_components/kia_uvo/lock.py
+++ b/custom_components/kia_uvo/lock.py
@@ -45,7 +45,7 @@ class HyundaiKiaConnectLock(LockEntity, HyundaiKiaConnectEntity):
     ):
         HyundaiKiaConnectEntity.__init__(self, coordinator, vehicle)
         self._attr_unique_id = f"{DOMAIN}_{vehicle.id}_door_lock"
-        self._attr_name = f"{vehicle.name} Door Lock"
+        self._attr_name = "Door Lock"
 
     @property
     def icon(self):

--- a/custom_components/kia_uvo/number.py
+++ b/custom_components/kia_uvo/number.py
@@ -99,7 +99,7 @@ class HyundaiKiaConnectNumber(NumberEntity, HyundaiKiaConnectEntity):
         self._attr_unique_id = f"{DOMAIN}_{vehicle.id}_{self._key}"
         self._attr_icon = self._description.icon
         self._attr_mode = NumberMode.SLIDER
-        self._attr_name = f"{vehicle.name} {self._description.name}"
+        self._attr_name = self._description.name
         self._attr_device_class = self._description.device_class
 
     @property

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -323,7 +323,7 @@ class HyundaiKiaConnectSensor(SensorEntity, HyundaiKiaConnectEntity):
         self._key = self._description.key
         self._attr_unique_id = f"{DOMAIN}_{vehicle.id}_{self._key}"
         self._attr_icon = self._description.icon
-        self._attr_name = f"{vehicle.name} {self._description.name}"
+        self._attr_name = self._description.name
         self._attr_state_class = self._description.state_class
         self._attr_device_class = self._description.device_class
         if description.entity_category:
@@ -374,7 +374,7 @@ class VehicleEntity(SensorEntity, HyundaiKiaConnectEntity):
 
     @property
     def name(self):
-        return f"{self.vehicle.name} Data"
+        return "Data"
 
     @property
     def unique_id(self):
@@ -408,7 +408,7 @@ class DailyDrivingStatsEntity(SensorEntity, HyundaiKiaConnectEntity):
 
     @property
     def name(self):
-        return f"{self.vehicle.name} Daily Driving Stats"
+        return "Daily Driving Stats"
 
     @property
     def unique_id(self):
@@ -462,7 +462,7 @@ class TodaysDailyDrivingStatsEntity(SensorEntity, HyundaiKiaConnectEntity):
 
     @property
     def name(self):
-        return f"{self.vehicle.name} Todays Daily Driving Stats"
+        return "Todays Daily Driving Stats"
 
     @property
     def unique_id(self):


### PR DESCRIPTION
## Summary
Adjust the integration to Home Assistant's 2026.4+ entity naming model so vehicle entities no longer end up with duplicated name prefixes on newer HA versions.

## Changes
- set `_attr_has_entity_name = True` on the shared base entity
- stop prefixing entity names with `vehicle.name`
- keep the vehicle name on the device only
- register the device with separate `name` and `model` values instead of using `"{name} ({model})"` for both

## Why
With recent Home Assistant versions, the device name is used when composing friendly names for entities that have `has_entity_name = True`.

This integration was still embedding the vehicle name directly into each entity name while also exposing a device name like `"{name} ({model})"`, which could lead to names such as:

- `<vehicle name> (<vehicle model>) <vehicle name> Air Conditioner`

After this change, the registry and UI use the expected split:

- device name: `<vehicle.name>`
- device model: `<vehicle.model>`
- entity original name: `Air Conditioner`
- friendly name: `<vehicle.name> Air Conditioner`

This better matches Home Assistant's naming model than storing `"{name} ({model})"` in both device fields.

## Compatibility
This should not change existing `unique_id`s and should not require entity ID migration for existing installs.

For new installs, entity IDs should remain in the same shape as before, for example:
- `binary_sensor.<vehicle_name_slug>_air_conditioner`
- `sensor.<vehicle_name_slug>_last_updated_at`
- `lock.<vehicle_name_slug>_door_lock`

## Verification
- validated locally with `py -m compileall custom_components\\kia_uvo`
- deployed to a Home Assistant dev instance
- confirmed updated device/entity registry values and corrected friendly names there

Fixes #1584.
