### PR TITLE
fix: reduce duplicate request errors and improve post-action refresh handling for set charge limits

### DIFF
--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -190,6 +190,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
     async def async_force_refresh_vehicle(self, vehicle_id: str) -> None:
         """Force refresh a single vehicle's state."""
         await self.async_check_and_refresh_token()
+        await asyncio.sleep(20)
         await self.hass.async_add_executor_job(
             self.vehicle_manager.force_refresh_vehicle_state, vehicle_id
         )
@@ -238,6 +239,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
             )
         finally:
             try:
+                await asyncio.sleep(60)
                 await self.hass.async_add_executor_job(
                     self.vehicle_manager.force_refresh_vehicle_state, vehicle_id
                 )
@@ -350,6 +352,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
     async def async_set_charge_limits(self, vehicle_id: str, ac: int, dc: int):
         await self.async_check_and_refresh_token()
         try:
+            await asyncio.sleep(5)
             action_id = await self.hass.async_add_executor_job(
                 self.vehicle_manager.set_charge_limits, vehicle_id, ac, dc
             )

--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -214,6 +214,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
                 60,
             )
         finally:
+            await asyncio.sleep(40)
             await self.async_refresh()
 
     async def async_await_action_and_force_refresh(self, vehicle_id, action_id):
@@ -359,7 +360,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
         except Exception as err:
             raise HomeAssistantError(f"Failed to set charge limits: {err}") from err
         self.hass.async_create_task(
-            self.async_await_action_and_force_refresh(vehicle_id, action_id)
+            self.async_await_action_and_refresh(vehicle_id, action_id)
         )
 
     async def async_set_charging_current(self, vehicle_id: str, level: int):


### PR DESCRIPTION
Tested on EU Hyundai Ioniq 5 (2025) and Kia EV3 (2025).

Calling force_refresh_vehicle_state() immediately after previous requests can trigger "Duplicate request" (4004) errors from the backend.

Adding a small delay before force refresh reduces the frequency of these failures and makes manual force updates more reliable. This appears to be related to backend timing/rate limiting rather than incorrect request parameters.

After set_charge_limits, the current flow uses force_refresh_vehicle_state(). In this situation, the force refresh sequence can fail in _get_location() with "Duplicate request" (4004), and may also return incomplete data.

In my testing, the updated charge limits become available via normal cached refresh after a short delay (~40 seconds), though possibly this may vary depending on backend timing. This change replaces the post-action force refresh with a delayed normal refresh.

This avoids duplicate request errors and provides stable retrieval of updated charge limits without additional API load.

Related to:
- Hyundai-Kia-Connect/kia_uvo#1620
- Hyundai-Kia-Connect/kia_uvo#1617
- https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/pull/1102
