### PR TITLE
fix: entity creation bugs for HEV vehicles and missing climate support

### DIFF
--- a/custom_components/kia_uvo/climate.py
+++ b/custom_components/kia_uvo/climate.py
@@ -15,7 +15,7 @@ from homeassistant.components.climate.const import (
 )
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -33,9 +33,12 @@ async def async_setup_entry(
 ) -> None:
     """Set up binary_sensor platform."""
     coordinator = hass.data[DOMAIN][config_entry.unique_id]
+    entities = []
     for vehicle_id in coordinator.vehicle_manager.vehicles.keys():
         vehicle: Vehicle = coordinator.vehicle_manager.vehicles[vehicle_id]
-        async_add_entities([HyundaiKiaCarClimateControlSwitch(coordinator, vehicle)])
+        if vehicle.air_control_is_on is not None:
+            entities.append(HyundaiKiaCarClimateControlSwitch(coordinator, vehicle))
+    async_add_entities(entities, True)
 
 
 PARALLEL_UPDATES = 1
@@ -102,7 +105,9 @@ class HyundaiKiaCarClimateControlSwitch(HyundaiKiaConnectEntity, ClimateEntity):
     @property
     def temperature_unit(self) -> str:
         """Get the Cars Climate Control Temperature Unit."""
-        return self.vehicle._air_temperature_unit
+        if self.vehicle._air_temperature_unit:
+            return UnitOfTemperature(self.vehicle._air_temperature_unit)
+        return UnitOfTemperature.CELSIUS
 
     @property
     def current_temperature(self) -> float | None:

--- a/custom_components/kia_uvo/number.py
+++ b/custom_components/kia_uvo/number.py
@@ -69,12 +69,7 @@ async def async_setup_entry(
     for vehicle_id in coordinator.vehicle_manager.vehicles.keys():
         vehicle: Vehicle = coordinator.vehicle_manager.vehicles[vehicle_id]
         for description in NUMBER_DESCRIPTIONS:
-            if description.key in (AC_CHARGING_LIMIT_KEY, DC_CHARGING_LIMIT_KEY):
-                if getattr(vehicle, "ev_battery_percentage", None) is not None:
-                    entities.append(
-                        HyundaiKiaConnectNumber(coordinator, description, vehicle)
-                    )
-            elif getattr(vehicle, description.key, None) is not None:
+            if getattr(vehicle, description.key, None) is not None:
                 entities.append(
                     HyundaiKiaConnectNumber(coordinator, description, vehicle)
                 )

--- a/custom_components/kia_uvo/switch.py
+++ b/custom_components/kia_uvo/switch.py
@@ -35,7 +35,7 @@ SWITCH_DESCRIPTIONS: Final[tuple[HyundaiKiaSwitchDescription, ...]] = (
         translation_key="ev_charging",
         icon="mdi:ev-station",
         value_fn=lambda vehicle: vehicle.ev_battery_is_charging,
-        exists_fn=lambda vehicle: vehicle.ev_battery_percentage is not None,
+        exists_fn=lambda vehicle: vehicle.ev_battery_is_charging is not None,
         on_fn=lambda coordinator, vid: coordinator.async_start_charge(vid),
         off_fn=lambda coordinator, vid: coordinator.async_stop_charge(vid),
     ),


### PR DESCRIPTION
## Summary

Fixes bugs that cause incorrect entity creation on HEV (hybrid) vehicles and vehicles without remote climate support.

### Changes

- **`number.py`**: Change `exists_fn` from `vehicle.ev_battery_percentage is not None` to `getattr(vehicle, description.key, None) is not None` — prevents charge limit entities from being incorrectly created on HEVs that have `ev_battery_percentage` but not `ev_charge_limits_ac`/`ev_charge_limits_dc`
- **`switch.py`**: Change `exists_fn` for `ev_charging` from `vehicle.ev_battery_percentage is not None` to `vehicle.ev_battery_is_charging is not None` — prevents charging switch from appearing on HEVs that don't support EV charging control
- **`climate.py`**: Add `None` guard on `air_control_is_on` to prevent climate entity creation on vehicles that don't support remote climate control. Add `UnitOfTemperature.CELSIUS` fallback when `_air_temperature_unit` is `None`

### Testing

Validated against live Hyundai EU API (Santa Fe HEV):
- `ev_battery_percentage=40.5` exists but `ev_charge_limits_ac=None` and `ev_charge_limits_dc=None` — confirms bug fix prevents incorrect entity creation
- `ev_battery_is_charging=None` — confirms charging switch correctly won't appear on HEV
- `air_control_is_on=0` — confirms climate entity correctly would be created (was previously `None`-unsafe)

This is the base PR for the following feature PRs: #2 (cover), #4 (climate), #5 (CCS2 sensors), #6 (binary sensors), #7 (buttons), #8 (departure), #9 (thermal), #10 (V2L).

## Test plan

- [ ] Install on HEV vehicle and verify no charge limit number entities are created
- [ ] Install on HEV vehicle and verify no charging switch is created
- [ ] Install on vehicle without climate support and verify no climate entity is created
- [ ] Verify existing EV/PHEV vehicles still create charge limits, charging switch, and climate correctly