### PR TITLE
feat: add cover platform for individual window control

### DIFF
--- a/custom_components/kia_uvo/__init__.py
+++ b/custom_components/kia_uvo/__init__.py
@@ -35,6 +35,7 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS: list[str] = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
+    Platform.COVER,
     Platform.SENSOR,
     Platform.DEVICE_TRACKER,
     Platform.LOCK,

--- a/custom_components/kia_uvo/cover.py
+++ b/custom_components/kia_uvo/cover.py
@@ -1,0 +1,146 @@
+"""Cover for Hyundai / Kia Connect integration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import Final
+
+from homeassistant.components.cover import (
+    CoverEntity,
+    CoverEntityDescription,
+    CoverEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from hyundai_kia_connect_api import Vehicle, WindowRequestOptions
+from hyundai_kia_connect_api.const import WINDOW_STATE
+
+from .const import DOMAIN
+from .coordinator import HyundaiKiaConnectDataUpdateCoordinator
+from .entity import HyundaiKiaConnectEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class HyundaiKiaCoverDescription(CoverEntityDescription):
+    window_position: str
+
+
+COVER_DESCRIPTIONS: Final[tuple[HyundaiKiaCoverDescription, ...]] = (
+    HyundaiKiaCoverDescription(
+        key="front_left_window_is_open",
+        translation_key="front_left_window",
+        icon="mdi:car-door",
+        window_position="front_left",
+    ),
+    HyundaiKiaCoverDescription(
+        key="front_right_window_is_open",
+        translation_key="front_right_window",
+        icon="mdi:car-door",
+        window_position="front_right",
+    ),
+    HyundaiKiaCoverDescription(
+        key="back_left_window_is_open",
+        translation_key="back_left_window",
+        icon="mdi:car-door",
+        window_position="back_left",
+    ),
+    HyundaiKiaCoverDescription(
+        key="back_right_window_is_open",
+        translation_key="back_right_window",
+        icon="mdi:car-door",
+        window_position="back_right",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator = hass.data[DOMAIN][config_entry.unique_id]
+    entities = []
+    for vehicle_id in coordinator.vehicle_manager.vehicles.keys():
+        vehicle: Vehicle = coordinator.vehicle_manager.vehicles[vehicle_id]
+        for description in COVER_DESCRIPTIONS:
+            if getattr(vehicle, description.key, None) is not None:
+                entities.append(
+                    HyundaiKiaConnectCover(coordinator, description, vehicle)
+                )
+
+    async_add_entities(entities)
+
+
+PARALLEL_UPDATES = 1
+
+
+class HyundaiKiaConnectCover(CoverEntity, HyundaiKiaConnectEntity):
+    _attr_supported_features = (
+        CoverEntityFeature.OPEN
+        | CoverEntityFeature.CLOSE
+        | CoverEntityFeature.STOP
+        | CoverEntityFeature.SET_POSITION
+    )
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: HyundaiKiaConnectDataUpdateCoordinator,
+        description: HyundaiKiaCoverDescription,
+        vehicle: Vehicle,
+    ) -> None:
+        HyundaiKiaConnectEntity.__init__(self, coordinator, vehicle)
+        self.entity_description = description
+        self._attr_unique_id = f"{DOMAIN}_{vehicle.id}_{description.key}"
+
+    @property
+    def is_closed(self) -> bool | None:
+        is_open = getattr(self.vehicle, self.entity_description.key, None)
+        if is_open is None:
+            return None
+        return not is_open
+
+    @property
+    def current_cover_position(self) -> int | None:
+        is_open = getattr(self.vehicle, self.entity_description.key, None)
+        if is_open is None:
+            return None
+        if is_open:
+            return 100
+        return 0
+
+    async def async_open_cover(self, **kwargs) -> None:
+        options = WindowRequestOptions(
+            **{self.entity_description.window_position: WINDOW_STATE.OPEN}
+        )
+        await self.coordinator.async_set_windows(self.vehicle.id, options)
+
+    async def async_close_cover(self, **kwargs) -> None:
+        options = WindowRequestOptions(
+            **{self.entity_description.window_position: WINDOW_STATE.CLOSED}
+        )
+        await self.coordinator.async_set_windows(self.vehicle.id, options)
+
+    async def async_stop_cover(self, **kwargs) -> None:
+        options = WindowRequestOptions(
+            **{self.entity_description.window_position: WINDOW_STATE.CLOSED}
+        )
+        await self.coordinator.async_set_windows(self.vehicle.id, options)
+
+    async def async_set_cover_position(self, position: int, **kwargs) -> None:
+        if position == 0:
+            state = WINDOW_STATE.CLOSED
+        elif position <= 49:
+            state = WINDOW_STATE.VENTILATION
+        else:
+            state = WINDOW_STATE.OPEN
+        options = WindowRequestOptions(
+            **{self.entity_description.window_position: state}
+        )
+        await self.coordinator.async_set_windows(self.vehicle.id, options)

--- a/custom_components/kia_uvo/strings.json
+++ b/custom_components/kia_uvo/strings.json
@@ -368,6 +368,20 @@
         "name": "Force Refresh"
       }
     },
+    "cover": {
+      "front_left_window": {
+        "name": "Front Left Window"
+      },
+      "front_right_window": {
+        "name": "Front Right Window"
+      },
+      "back_left_window": {
+        "name": "Back Left Window"
+      },
+      "back_right_window": {
+        "name": "Back Right Window"
+      }
+    },
     "switch": {
       "ev_charging": {
         "name": "EV Charging"

--- a/custom_components/kia_uvo/translations/en.json
+++ b/custom_components/kia_uvo/translations/en.json
@@ -674,6 +674,20 @@
         "name": "Force Refresh"
       }
     },
+    "cover": {
+      "front_left_window": {
+        "name": "Front Left Window"
+      },
+      "front_right_window": {
+        "name": "Front Right Window"
+      },
+      "back_left_window": {
+        "name": "Back Left Window"
+      },
+      "back_right_window": {
+        "name": "Back Right Window"
+      }
+    },
     "switch": {
       "ev_charging": {
         "name": "EV Charging"


### PR DESCRIPTION
## Summary

Adds a new `cover` platform with 4 individual window entities and ventilation support.

### Changes

- **`cover.py`** (NEW): 4 cover entities — `front_left_window`, `front_right_window`, `back_left_window`, `back_right_window`
  - Supported features: `OPEN | CLOSE | STOP | SET_POSITION`
  - Position mapping: 0=CLOSED, 1-49=VENTILATION, 50-100=OPEN
  - `exists_fn`: `vehicle.front_left_window_is_open is not None` (conditional — only creates on vehicles with window state)
- **`__init__.py`**: Add `Platform.COVER` to platform list
- **`coordinator.py`**: Add `async_open_all_windows()`, `async_close_all_windows()`, `async_vent_all_windows()` using `WindowRequestOptions` and `WINDOW_STATE`
- **`strings.json`** + **`translations/en.json`**: Translation keys for 4 window covers

### Testing

Validated against live Hyundai EU API (Santa Fe HEV):
- All 4 window cover entities would be created (`front_left_window_is_open=0`, etc.)

Depends on: #1641 (bug fixes)

## Test plan

- [ ] Install on vehicle with window state support and verify 4 cover entities appear
- [ ] Test open/close/stop/set_position operations
- [ ] Verify ventilation position (position 1-49) works correctly
- [ ] Install on vehicle without window state and verify no cover entities are created