### PR TITLE
feat: add individual door lock sensors and EV battery winter mode

### DIFF
--- a/custom_components/kia_uvo/binary_sensor.py
+++ b/custom_components/kia_uvo/binary_sensor.py
@@ -452,6 +452,48 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         off_icon="mdi:seat-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    HyundaiKiaBinarySensorEntityDescription(
+        key="front_left_door_is_locked",
+        translation_key="front_left_door_is_locked",
+        device_class=BinarySensorDeviceClass.LOCK,
+        is_on=lambda vehicle: not vehicle.front_left_door_is_locked,
+        on_icon="mdi:lock-open",
+        off_icon="mdi:lock",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    HyundaiKiaBinarySensorEntityDescription(
+        key="front_right_door_is_locked",
+        translation_key="front_right_door_is_locked",
+        device_class=BinarySensorDeviceClass.LOCK,
+        is_on=lambda vehicle: not vehicle.front_right_door_is_locked,
+        on_icon="mdi:lock-open",
+        off_icon="mdi:lock",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    HyundaiKiaBinarySensorEntityDescription(
+        key="back_left_door_is_locked",
+        translation_key="back_left_door_is_locked",
+        device_class=BinarySensorDeviceClass.LOCK,
+        is_on=lambda vehicle: not vehicle.back_left_door_is_locked,
+        on_icon="mdi:lock-open",
+        off_icon="mdi:lock",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    HyundaiKiaBinarySensorEntityDescription(
+        key="back_right_door_is_locked",
+        translation_key="back_right_door_is_locked",
+        device_class=BinarySensorDeviceClass.LOCK,
+        is_on=lambda vehicle: not vehicle.back_right_door_is_locked,
+        on_icon="mdi:lock-open",
+        off_icon="mdi:lock",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    HyundaiKiaBinarySensorEntityDescription(
+        key="ev_battery_winter_mode",
+        translation_key="ev_battery_winter_mode",
+        icon="mdi:snowflake-thermometer",
+        is_on=lambda vehicle: vehicle.ev_battery_winter_mode,
+    ),
 )
 
 

--- a/custom_components/kia_uvo/strings.json
+++ b/custom_components/kia_uvo/strings.json
@@ -356,6 +356,21 @@
       },
       "rear_right_seat_heater_on": {
         "name": "Rear Right Seat Heater"
+      },
+      "front_left_door_is_locked": {
+        "name": "Front Left Door Lock"
+      },
+      "front_right_door_is_locked": {
+        "name": "Front Right Door Lock"
+      },
+      "back_left_door_is_locked": {
+        "name": "Back Left Door Lock"
+      },
+      "back_right_door_is_locked": {
+        "name": "Back Right Door Lock"
+      },
+      "ev_battery_winter_mode": {
+        "name": "EV Battery Winter Mode"
       }
     },
     "lock": {

--- a/custom_components/kia_uvo/translations/en.json
+++ b/custom_components/kia_uvo/translations/en.json
@@ -662,6 +662,21 @@
       },
       "rear_right_seat_heater_on": {
         "name": "Rear Right Seat Heater"
+      },
+      "front_left_door_is_locked": {
+        "name": "Front Left Door Lock"
+      },
+      "front_right_door_is_locked": {
+        "name": "Front Right Door Lock"
+      },
+      "back_left_door_is_locked": {
+        "name": "Back Left Door Lock"
+      },
+      "back_right_door_is_locked": {
+        "name": "Back Right Door Lock"
+      },
+      "ev_battery_winter_mode": {
+        "name": "EV Battery Winter Mode"
       }
     },
     "lock": {


### PR DESCRIPTION
## Summary

Adds 5 new binary sensors: 4 individual door lock states and EV battery winter mode indicator.

### New binary sensors

| Key | Translation key | Device class | `is_on` logic |
|---|---|---|---|
| `front_left_door_is_locked` | `front_left_door_is_locked` | `LOCK` | `not vehicle.front_left_door_is_locked` (inverted: on = unlocked) |
| `front_right_door_is_locked` | `front_right_door_is_locked` | `LOCK` | `not vehicle.front_right_door_is_locked` |
| `back_left_door_is_locked` | `back_left_door_is_locked` | `LOCK` | `not vehicle.back_left_door_is_locked` |
| `back_right_door_is_locked` | `back_right_door_is_locked` | `LOCK` | `not vehicle.back_right_door_is_locked` |
| `ev_battery_winter_mode` | `ev_battery_winter_mode` | — | direct boolean |

Note: Home Assistant `LOCK` device class uses inverted logic — `on` means unlocked. The `is_on` lambda inverts the Vehicle model's boolean to match this convention.

All new entities use `getattr(vehicle, description.key, None) is not None` for conditional creation.

### Testing

Validated against live Hyundai EU API (Santa Fe HEV):
- All 4 door lock sensors return `True` (locked) — `is_locked=True`
- `ev_battery_winter_mode=False` — winter mode is off

Depends on: #1641 (bug fixes)

## Test plan

- [ ] Install on vehicle with door lock state support and verify 4 lock binary sensors appear
- [ ] Verify lock state inversion (HA: on = unlocked, off = locked)
- [ ] Install on EV vehicle and verify `ev_battery_winter_mode` binary sensor appears
- [ ] Install on vehicle without these attributes and verify no extra entities are created