### PR TITLE
feat: add EV thermal diagnostics and outside temperature

### DIFF
--- a/custom_components/kia_uvo/binary_sensor.py
+++ b/custom_components/kia_uvo/binary_sensor.py
@@ -494,6 +494,20 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         icon="mdi:snowflake-thermometer",
         is_on=lambda vehicle: vehicle.ev_battery_winter_mode,
     ),
+    HyundaiKiaBinarySensorEntityDescription(
+        key="ev_battery_precondition_enabled",
+        translation_key="ev_battery_precondition_enabled",
+        icon="mdi:battery-charging-high",
+        is_on=lambda vehicle: vehicle.ev_battery_precondition_enabled,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    HyundaiKiaBinarySensorEntityDescription(
+        key="ev_battery_heating_state",
+        translation_key="ev_battery_heating_state",
+        icon="mdi:fire",
+        is_on=lambda vehicle: vehicle.ev_battery_heating_state,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
 )
 
 

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -18,7 +18,6 @@ from homeassistant.const import (
     PERCENTAGE,
     UnitOfEnergy,
     UnitOfPower,
-    UnitOfTemperature,
     UnitOfTime,
     EntityCategory,
 )
@@ -274,12 +273,12 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SensorEntityDescription(
-        key="outside_temperature",
+        key="_outside_temperature",
         translation_key="outside_temperature",
         icon="mdi:thermometer",
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        native_unit_of_measurement=DYNAMIC_UNIT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SensorEntityDescription(

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     PERCENTAGE,
     UnitOfEnergy,
     UnitOfPower,
+    UnitOfTemperature,
     UnitOfTime,
     EntityCategory,
 )
@@ -270,6 +271,29 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         key="VIN",
         translation_key="vehicle_identification_number",
         icon="mdi:identifier",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SensorEntityDescription(
+        key="outside_temperature",
+        translation_key="outside_temperature",
+        icon="mdi:thermometer",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SensorEntityDescription(
+        key="engine_type",
+        translation_key="engine_type",
+        icon="mdi:engine",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SensorEntityDescription(
+        key="ev_battery_chiller_rpm",
+        translation_key="ev_battery_chiller_rpm",
+        icon="mdi:fan",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="rpm",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
 )

--- a/custom_components/kia_uvo/strings.json
+++ b/custom_components/kia_uvo/strings.json
@@ -88,47 +88,53 @@
   },
   "entity": {
     "sensor": {
-      "total_driving_range": {
-        "name": "Total Driving Range"
-      },
-      "odometer": {
-        "name": "Odometer"
-      },
-      "last_service_distance": {
-        "name": "Last Service"
-      },
-      "next_service_distance": {
-        "name": "Next Service"
+      "air_temperature": {
+        "name": "Set Temperature"
       },
       "car_battery_percentage": {
         "name": "Car Battery Level"
       },
-      "last_updated_at": {
-        "name": "Last Updated At"
+      "daily_driving_stats": {
+        "name": "Daily Driving Stats"
       },
-      "ev_battery_percentage": {
-        "name": "EV Battery Level"
+      "data": {
+        "name": "Data"
       },
-      "ev_battery_soh_percentage": {
-        "name": "EV State of Health Battery"
-      },
-      "ev_battery_remain": {
-        "name": "EV Battery Remaining Energy"
+      "dtc_count": {
+        "name": "DTC Count"
       },
       "ev_battery_capacity": {
         "name": "EV Battery Capacity"
       },
+      "ev_battery_pack_voltage": {
+        "name": "EV battery pack voltage"
+      },
+      "ev_battery_percentage": {
+        "name": "EV Battery Level"
+      },
+      "ev_battery_remain": {
+        "name": "EV Battery Remaining Energy"
+      },
+      "ev_battery_soh_percentage": {
+        "name": "EV State of Health Battery"
+      },
+      "ev_battery_temperature_max": {
+        "name": "EV battery temperature max"
+      },
+      "ev_battery_temperature_min": {
+        "name": "EV battery temperature min"
+      },
+      "ev_battery_water_temperature": {
+        "name": "EV battery water temperature"
+      },
+      "ev_charging_current": {
+        "name": "EV Charging Current Limit"
+      },
+      "ev_charging_power": {
+        "name": "EV Charging Power"
+      },
       "ev_driving_range": {
         "name": "EV Range"
-      },
-      "fuel_driving_range": {
-        "name": "Fuel Driving Range"
-      },
-      "fuel_level": {
-        "name": "Fuel Level"
-      },
-      "air_temperature": {
-        "name": "Set Temperature"
       },
       "ev_estimated_current_charge_duration": {
         "name": "Estimated Charge Duration"
@@ -142,20 +148,23 @@
       "ev_estimated_station_charge_duration": {
         "name": "Estimated Station Charge Duration"
       },
+      "ev_first_departure_time": {
+        "name": "EV First Scheduled Departure Time"
+      },
+      "ev_off_peak_end_time": {
+        "name": "EV Off Peak End Time"
+      },
+      "ev_off_peak_start_time": {
+        "name": "EV Off Peak Start Time"
+      },
+      "ev_second_departure_time": {
+        "name": "EV Second Scheduled Departure Time"
+      },
       "ev_target_range_charge_ac": {
         "name": "Target Range of Charge AC"
       },
       "ev_target_range_charge_dc": {
         "name": "Target Range of Charge DC"
-      },
-      "total_power_consumed": {
-        "name": "90 Day Energy Consumption"
-      },
-      "total_power_regenerated": {
-        "name": "Total Energy Regeneration"
-      },
-      "power_consumption_30d": {
-        "name": "Average Energy Consumption"
       },
       "front_left_seat_status": {
         "name": "Front Left Seat"
@@ -163,94 +172,94 @@
       "front_right_seat_status": {
         "name": "Front Right Seat"
       },
+      "fuel_driving_range": {
+        "name": "Fuel Driving Range"
+      },
+      "fuel_level": {
+        "name": "Fuel Level"
+      },
+      "geocode_name": {
+        "name": "Geocoded Location"
+      },
+      "last_service_distance": {
+        "name": "Last Service"
+      },
+      "last_updated_at": {
+        "name": "Last Updated At"
+      },
+      "next_service_distance": {
+        "name": "Next Service"
+      },
+      "odometer": {
+        "name": "Odometer"
+      },
+      "outside_temperature": {
+        "name": "Outside temperature"
+      },
+      "power_consumption_30d": {
+        "name": "Average Energy Consumption"
+      },
       "rear_left_seat_status": {
         "name": "Rear Left Seat"
       },
       "rear_right_seat_status": {
         "name": "Rear Right Seat"
       },
-      "geocode_name": {
-        "name": "Geocoded Location"
+      "todays_daily_driving_stats": {
+        "name": "Today's Daily Driving Stats"
       },
-      "dtc_count": {
-        "name": "DTC Count"
+      "total_driving_range": {
+        "name": "Total Driving Range"
       },
-      "ev_first_departure_time": {
-        "name": "EV First Scheduled Departure Time"
+      "total_power_consumed": {
+        "name": "90 Day Energy Consumption"
       },
-      "ev_second_departure_time": {
-        "name": "EV Second Scheduled Departure Time"
-      },
-      "ev_off_peak_start_time": {
-        "name": "EV Off Peak Start Time"
-      },
-      "ev_off_peak_end_time": {
-        "name": "EV Off Peak End Time"
-      },
-      "ev_charging_current": {
-        "name": "EV Charging Current Limit"
-      },
-      "ev_charging_power": {
-        "name": "EV Charging Power"
+      "total_power_regenerated": {
+        "name": "Total Energy Regeneration"
       },
       "vehicle_identification_number": {
         "name": "Vehicle Identification Number"
-      },
-      "data": {
-        "name": "Data"
-      },
-      "daily_driving_stats": {
-        "name": "Daily Driving Stats"
-      },
-      "todays_daily_driving_stats": {
-        "name": "Today's Daily Driving Stats"
       }
     },
     "binary_sensor": {
-      "engine_is_running": {
-        "name": "Engine"
+      "accessory_on": {
+        "name": "Accessory"
       },
-      "defrost_is_on": {
-        "name": "Defrost"
+      "air_control_is_on": {
+        "name": "Air Conditioner"
       },
-      "steering_wheel_heater_is_on": {
-        "name": "Steering Wheel Heater"
-      },
-      "back_window_heater_is_on": {
-        "name": "Back Window Heater"
-      },
-      "side_mirror_heater_is_on": {
-        "name": "Side Mirror Heater"
-      },
-      "front_left_door_is_open": {
-        "name": "Front Left Door"
-      },
-      "front_right_door_is_open": {
-        "name": "Front Right Door"
+      "back_left_door_is_locked": {
+        "name": "Back Left Door Lock"
       },
       "back_left_door_is_open": {
         "name": "Back Left Door"
       },
-      "back_right_door_is_open": {
-        "name": "Back Right Door"
-      },
-      "trunk_is_open": {
-        "name": "Trunk"
-      },
-      "hood_is_open": {
-        "name": "Hood"
-      },
-      "front_left_window_is_open": {
-        "name": "Front Left Window"
-      },
-      "front_right_window_is_open": {
-        "name": "Front Right Window"
-      },
       "back_left_window_is_open": {
         "name": "Back Left Window"
       },
+      "back_right_door_is_locked": {
+        "name": "Back Right Door Lock"
+      },
+      "back_right_door_is_open": {
+        "name": "Back Right Door"
+      },
       "back_right_window_is_open": {
         "name": "Back Right Window"
+      },
+      "back_window_heater_is_on": {
+        "name": "Back Window Heater"
+      },
+      "brake_fluid_warning_is_on": {
+        "name": "Brake Fluid Warning"
+      },
+      "defrost_is_on": {
+        "name": "Defrost"
+      },
+      "engine_is_running": {
+        "name": "Engine"
+      },
+      "ev_battery_heating_state": {
+        "name": "EV battery heating"
       },
       "ev_battery_is_charging": {
         "name": "EV Battery Charge"
@@ -258,32 +267,11 @@
       "ev_battery_is_plugged_in": {
         "name": "EV Battery Plug"
       },
-      "fuel_level_is_low": {
-        "name": "Fuel Low Level"
+      "ev_battery_precondition_enabled": {
+        "name": "EV battery precondition"
       },
-      "smart_key_battery_warning_is_on": {
-        "name": "Smart Key Battery Warning"
-      },
-      "washer_fluid_warning_is_on": {
-        "name": "Washer Fluid Warning"
-      },
-      "tire_pressure_all_warning_is_on": {
-        "name": "Tire Pressure - All"
-      },
-      "tire_pressure_rear_left_warning_is_on": {
-        "name": "Tire Pressure - Rear Left"
-      },
-      "tire_pressure_front_left_warning_is_on": {
-        "name": "Tire Pressure - Front Left"
-      },
-      "tire_pressure_front_right_warning_is_on": {
-        "name": "Tire Pressure - Front Right"
-      },
-      "tire_pressure_rear_right_warning_is_on": {
-        "name": "Tire Pressure - Rear Right"
-      },
-      "air_control_is_on": {
-        "name": "Air Conditioner"
+      "ev_battery_winter_mode": {
+        "name": "EV Battery Winter Mode"
       },
       "ev_charge_port_door_is_open": {
         "name": "EV Charge Port"
@@ -294,29 +282,32 @@
       "ev_second_departure_enabled": {
         "name": "EV Scheduled Departure 2"
       },
-      "brake_fluid_warning_is_on": {
-        "name": "Brake Fluid Warning"
+      "front_left_door_is_locked": {
+        "name": "Front Left Door Lock"
       },
-      "sunroof_is_open": {
-        "name": "Sunroof"
+      "front_left_door_is_open": {
+        "name": "Front Left Door"
       },
-      "accessory_on": {
-        "name": "Accessory"
+      "front_left_seat_heater_on": {
+        "name": "Front Left Seat Heater"
       },
-      "ign3": {
-        "name": "IGN3"
+      "front_left_window_is_open": {
+        "name": "Front Left Window"
       },
-      "remote_ignition": {
-        "name": "Remote Ignition"
+      "front_right_door_is_locked": {
+        "name": "Front Right Door Lock"
       },
-      "transmission_condition": {
-        "name": "Transmission Condition"
+      "front_right_door_is_open": {
+        "name": "Front Right Door"
       },
-      "sleep_mode_check": {
-        "name": "Sleep Mode Check"
+      "front_right_seat_heater_on": {
+        "name": "Front Right Seat Heater"
       },
-      "headlamp_status": {
-        "name": "Headlamp Status"
+      "front_right_window_is_open": {
+        "name": "Front Right Window"
+      },
+      "fuel_level_is_low": {
+        "name": "Fuel Low Level"
       },
       "headlamp_left_low": {
         "name": "Front Left Lamp Fault"
@@ -324,32 +315,17 @@
       "headlamp_right_low": {
         "name": "Front Right Lamp Fault"
       },
-      "stop_lamp_left": {
-        "name": "Rear Left Lamp Fault"
+      "headlamp_status": {
+        "name": "Headlamp Status"
       },
-      "stop_lamp_right": {
-        "name": "Rear Right Lamp Fault"
+      "hood_is_open": {
+        "name": "Hood"
       },
-      "turn_signal_left_front": {
-        "name": "Turn Signal Left Front"
-      },
-      "turn_signal_right_front": {
-        "name": "Turn Signal Right Front"
-      },
-      "turn_signal_left_rear": {
-        "name": "Turn Signal Left Rear"
-      },
-      "turn_signal_right_rear": {
-        "name": "Turn Signal Right Rear"
+      "ign3": {
+        "name": "IGN3"
       },
       "is_locked": {
         "name": "Locked"
-      },
-      "front_left_seat_heater_on": {
-        "name": "Front Left Seat Heater"
-      },
-      "front_right_seat_heater_on": {
-        "name": "Front Right Seat Heater"
       },
       "rear_left_seat_heater_on": {
         "name": "Rear Left Seat Heater"
@@ -357,20 +333,65 @@
       "rear_right_seat_heater_on": {
         "name": "Rear Right Seat Heater"
       },
-      "front_left_door_is_locked": {
-        "name": "Front Left Door Lock"
+      "remote_ignition": {
+        "name": "Remote Ignition"
       },
-      "front_right_door_is_locked": {
-        "name": "Front Right Door Lock"
+      "side_mirror_heater_is_on": {
+        "name": "Side Mirror Heater"
       },
-      "back_left_door_is_locked": {
-        "name": "Back Left Door Lock"
+      "sleep_mode_check": {
+        "name": "Sleep Mode Check"
       },
-      "back_right_door_is_locked": {
-        "name": "Back Right Door Lock"
+      "smart_key_battery_warning_is_on": {
+        "name": "Smart Key Battery Warning"
       },
-      "ev_battery_winter_mode": {
-        "name": "EV Battery Winter Mode"
+      "steering_wheel_heater_is_on": {
+        "name": "Steering Wheel Heater"
+      },
+      "stop_lamp_left": {
+        "name": "Rear Left Lamp Fault"
+      },
+      "stop_lamp_right": {
+        "name": "Rear Right Lamp Fault"
+      },
+      "sunroof_is_open": {
+        "name": "Sunroof"
+      },
+      "tire_pressure_all_warning_is_on": {
+        "name": "Tire Pressure - All"
+      },
+      "tire_pressure_front_left_warning_is_on": {
+        "name": "Tire Pressure - Front Left"
+      },
+      "tire_pressure_front_right_warning_is_on": {
+        "name": "Tire Pressure - Front Right"
+      },
+      "tire_pressure_rear_left_warning_is_on": {
+        "name": "Tire Pressure - Rear Left"
+      },
+      "tire_pressure_rear_right_warning_is_on": {
+        "name": "Tire Pressure - Rear Right"
+      },
+      "transmission_condition": {
+        "name": "Transmission Condition"
+      },
+      "trunk_is_open": {
+        "name": "Trunk"
+      },
+      "turn_signal_left_front": {
+        "name": "Turn Signal Left Front"
+      },
+      "turn_signal_left_rear": {
+        "name": "Turn Signal Left Rear"
+      },
+      "turn_signal_right_front": {
+        "name": "Turn Signal Right Front"
+      },
+      "turn_signal_right_rear": {
+        "name": "Turn Signal Right Rear"
+      },
+      "washer_fluid_warning_is_on": {
+        "name": "Washer Fluid Warning"
       }
     },
     "lock": {

--- a/custom_components/kia_uvo/translations/en.json
+++ b/custom_components/kia_uvo/translations/en.json
@@ -394,47 +394,53 @@
   },
   "entity": {
     "sensor": {
-      "total_driving_range": {
-        "name": "Total Driving Range"
-      },
-      "odometer": {
-        "name": "Odometer"
-      },
-      "last_service_distance": {
-        "name": "Last Service"
-      },
-      "next_service_distance": {
-        "name": "Next Service"
+      "air_temperature": {
+        "name": "Set Temperature"
       },
       "car_battery_percentage": {
         "name": "Car Battery Level"
       },
-      "last_updated_at": {
-        "name": "Last Updated At"
+      "daily_driving_stats": {
+        "name": "Daily Driving Stats"
       },
-      "ev_battery_percentage": {
-        "name": "EV Battery Level"
+      "data": {
+        "name": "Data"
       },
-      "ev_battery_soh_percentage": {
-        "name": "EV State of Health Battery"
-      },
-      "ev_battery_remain": {
-        "name": "EV Battery Remaining Energy"
+      "dtc_count": {
+        "name": "DTC Count"
       },
       "ev_battery_capacity": {
         "name": "EV Battery Capacity"
       },
+      "ev_battery_pack_voltage": {
+        "name": "EV battery pack voltage"
+      },
+      "ev_battery_percentage": {
+        "name": "EV Battery Level"
+      },
+      "ev_battery_remain": {
+        "name": "EV Battery Remaining Energy"
+      },
+      "ev_battery_soh_percentage": {
+        "name": "EV State of Health Battery"
+      },
+      "ev_battery_temperature_max": {
+        "name": "EV battery temperature max"
+      },
+      "ev_battery_temperature_min": {
+        "name": "EV battery temperature min"
+      },
+      "ev_battery_water_temperature": {
+        "name": "EV battery water temperature"
+      },
+      "ev_charging_current": {
+        "name": "EV Charging Current Limit"
+      },
+      "ev_charging_power": {
+        "name": "EV Charging Power"
+      },
       "ev_driving_range": {
         "name": "EV Range"
-      },
-      "fuel_driving_range": {
-        "name": "Fuel Driving Range"
-      },
-      "fuel_level": {
-        "name": "Fuel Level"
-      },
-      "air_temperature": {
-        "name": "Set Temperature"
       },
       "ev_estimated_current_charge_duration": {
         "name": "Estimated Charge Duration"
@@ -448,20 +454,23 @@
       "ev_estimated_station_charge_duration": {
         "name": "Estimated Station Charge Duration"
       },
+      "ev_first_departure_time": {
+        "name": "EV First Scheduled Departure Time"
+      },
+      "ev_off_peak_end_time": {
+        "name": "EV Off Peak End Time"
+      },
+      "ev_off_peak_start_time": {
+        "name": "EV Off Peak Start Time"
+      },
+      "ev_second_departure_time": {
+        "name": "EV Second Scheduled Departure Time"
+      },
       "ev_target_range_charge_ac": {
         "name": "Target Range of Charge AC"
       },
       "ev_target_range_charge_dc": {
         "name": "Target Range of Charge DC"
-      },
-      "total_power_consumed": {
-        "name": "90 Day Energy Consumption"
-      },
-      "total_power_regenerated": {
-        "name": "Total Energy Regeneration"
-      },
-      "power_consumption_30d": {
-        "name": "Average Energy Consumption"
       },
       "front_left_seat_status": {
         "name": "Front Left Seat"
@@ -469,94 +478,94 @@
       "front_right_seat_status": {
         "name": "Front Right Seat"
       },
+      "fuel_driving_range": {
+        "name": "Fuel Driving Range"
+      },
+      "fuel_level": {
+        "name": "Fuel Level"
+      },
+      "geocode_name": {
+        "name": "Geocoded Location"
+      },
+      "last_service_distance": {
+        "name": "Last Service"
+      },
+      "last_updated_at": {
+        "name": "Last Updated At"
+      },
+      "next_service_distance": {
+        "name": "Next Service"
+      },
+      "odometer": {
+        "name": "Odometer"
+      },
+      "outside_temperature": {
+        "name": "Outside temperature"
+      },
+      "power_consumption_30d": {
+        "name": "Average Energy Consumption"
+      },
       "rear_left_seat_status": {
         "name": "Rear Left Seat"
       },
       "rear_right_seat_status": {
         "name": "Rear Right Seat"
       },
-      "geocode_name": {
-        "name": "Geocoded Location"
+      "todays_daily_driving_stats": {
+        "name": "Today's Daily Driving Stats"
       },
-      "dtc_count": {
-        "name": "DTC Count"
+      "total_driving_range": {
+        "name": "Total Driving Range"
       },
-      "ev_first_departure_time": {
-        "name": "EV First Scheduled Departure Time"
+      "total_power_consumed": {
+        "name": "90 Day Energy Consumption"
       },
-      "ev_second_departure_time": {
-        "name": "EV Second Scheduled Departure Time"
-      },
-      "ev_off_peak_start_time": {
-        "name": "EV Off Peak Start Time"
-      },
-      "ev_off_peak_end_time": {
-        "name": "EV Off Peak End Time"
-      },
-      "ev_charging_current": {
-        "name": "EV Charging Current Limit"
-      },
-      "ev_charging_power": {
-        "name": "EV Charging Power"
+      "total_power_regenerated": {
+        "name": "Total Energy Regeneration"
       },
       "vehicle_identification_number": {
         "name": "Vehicle Identification Number"
-      },
-      "data": {
-        "name": "Data"
-      },
-      "daily_driving_stats": {
-        "name": "Daily Driving Stats"
-      },
-      "todays_daily_driving_stats": {
-        "name": "Today's Daily Driving Stats"
       }
     },
     "binary_sensor": {
-      "engine_is_running": {
-        "name": "Engine"
+      "accessory_on": {
+        "name": "Accessory"
       },
-      "defrost_is_on": {
-        "name": "Defrost"
+      "air_control_is_on": {
+        "name": "Air Conditioner"
       },
-      "steering_wheel_heater_is_on": {
-        "name": "Steering Wheel Heater"
-      },
-      "back_window_heater_is_on": {
-        "name": "Back Window Heater"
-      },
-      "side_mirror_heater_is_on": {
-        "name": "Side Mirror Heater"
-      },
-      "front_left_door_is_open": {
-        "name": "Front Left Door"
-      },
-      "front_right_door_is_open": {
-        "name": "Front Right Door"
+      "back_left_door_is_locked": {
+        "name": "Back Left Door Lock"
       },
       "back_left_door_is_open": {
         "name": "Back Left Door"
       },
-      "back_right_door_is_open": {
-        "name": "Back Right Door"
-      },
-      "trunk_is_open": {
-        "name": "Trunk"
-      },
-      "hood_is_open": {
-        "name": "Hood"
-      },
-      "front_left_window_is_open": {
-        "name": "Front Left Window"
-      },
-      "front_right_window_is_open": {
-        "name": "Front Right Window"
-      },
       "back_left_window_is_open": {
         "name": "Back Left Window"
       },
+      "back_right_door_is_locked": {
+        "name": "Back Right Door Lock"
+      },
+      "back_right_door_is_open": {
+        "name": "Back Right Door"
+      },
       "back_right_window_is_open": {
         "name": "Back Right Window"
+      },
+      "back_window_heater_is_on": {
+        "name": "Back Window Heater"
+      },
+      "brake_fluid_warning_is_on": {
+        "name": "Brake Fluid Warning"
+      },
+      "defrost_is_on": {
+        "name": "Defrost"
+      },
+      "engine_is_running": {
+        "name": "Engine"
+      },
+      "ev_battery_heating_state": {
+        "name": "EV battery heating"
       },
       "ev_battery_is_charging": {
         "name": "EV Battery Charge"
@@ -564,32 +573,11 @@
       "ev_battery_is_plugged_in": {
         "name": "EV Battery Plug"
       },
-      "fuel_level_is_low": {
-        "name": "Fuel Low Level"
+      "ev_battery_precondition_enabled": {
+        "name": "EV battery precondition"
       },
-      "smart_key_battery_warning_is_on": {
-        "name": "Smart Key Battery Warning"
-      },
-      "washer_fluid_warning_is_on": {
-        "name": "Washer Fluid Warning"
-      },
-      "tire_pressure_all_warning_is_on": {
-        "name": "Tire Pressure - All"
-      },
-      "tire_pressure_rear_left_warning_is_on": {
-        "name": "Tire Pressure - Rear Left"
-      },
-      "tire_pressure_front_left_warning_is_on": {
-        "name": "Tire Pressure - Front Left"
-      },
-      "tire_pressure_front_right_warning_is_on": {
-        "name": "Tire Pressure - Front Right"
-      },
-      "tire_pressure_rear_right_warning_is_on": {
-        "name": "Tire Pressure - Rear Right"
-      },
-      "air_control_is_on": {
-        "name": "Air Conditioner"
+      "ev_battery_winter_mode": {
+        "name": "EV Battery Winter Mode"
       },
       "ev_charge_port_door_is_open": {
         "name": "EV Charge Port"
@@ -600,29 +588,32 @@
       "ev_second_departure_enabled": {
         "name": "EV Scheduled Departure 2"
       },
-      "brake_fluid_warning_is_on": {
-        "name": "Brake Fluid Warning"
+      "front_left_door_is_locked": {
+        "name": "Front Left Door Lock"
       },
-      "sunroof_is_open": {
-        "name": "Sunroof"
+      "front_left_door_is_open": {
+        "name": "Front Left Door"
       },
-      "accessory_on": {
-        "name": "Accessory"
+      "front_left_seat_heater_on": {
+        "name": "Front Left Seat Heater"
       },
-      "ign3": {
-        "name": "IGN3"
+      "front_left_window_is_open": {
+        "name": "Front Left Window"
       },
-      "remote_ignition": {
-        "name": "Remote Ignition"
+      "front_right_door_is_locked": {
+        "name": "Front Right Door Lock"
       },
-      "transmission_condition": {
-        "name": "Transmission Condition"
+      "front_right_door_is_open": {
+        "name": "Front Right Door"
       },
-      "sleep_mode_check": {
-        "name": "Sleep Mode Check"
+      "front_right_seat_heater_on": {
+        "name": "Front Right Seat Heater"
       },
-      "headlamp_status": {
-        "name": "Headlamp Status"
+      "front_right_window_is_open": {
+        "name": "Front Right Window"
+      },
+      "fuel_level_is_low": {
+        "name": "Fuel Low Level"
       },
       "headlamp_left_low": {
         "name": "Front Left Lamp Fault"
@@ -630,32 +621,17 @@
       "headlamp_right_low": {
         "name": "Front Right Lamp Fault"
       },
-      "stop_lamp_left": {
-        "name": "Rear Left Lamp Fault"
+      "headlamp_status": {
+        "name": "Headlamp Status"
       },
-      "stop_lamp_right": {
-        "name": "Rear Right Lamp Fault"
+      "hood_is_open": {
+        "name": "Hood"
       },
-      "turn_signal_left_front": {
-        "name": "Turn Signal Left Front"
-      },
-      "turn_signal_right_front": {
-        "name": "Turn Signal Right Front"
-      },
-      "turn_signal_left_rear": {
-        "name": "Turn Signal Left Rear"
-      },
-      "turn_signal_right_rear": {
-        "name": "Turn Signal Right Rear"
+      "ign3": {
+        "name": "IGN3"
       },
       "is_locked": {
         "name": "Locked"
-      },
-      "front_left_seat_heater_on": {
-        "name": "Front Left Seat Heater"
-      },
-      "front_right_seat_heater_on": {
-        "name": "Front Right Seat Heater"
       },
       "rear_left_seat_heater_on": {
         "name": "Rear Left Seat Heater"
@@ -663,20 +639,65 @@
       "rear_right_seat_heater_on": {
         "name": "Rear Right Seat Heater"
       },
-      "front_left_door_is_locked": {
-        "name": "Front Left Door Lock"
+      "remote_ignition": {
+        "name": "Remote Ignition"
       },
-      "front_right_door_is_locked": {
-        "name": "Front Right Door Lock"
+      "side_mirror_heater_is_on": {
+        "name": "Side Mirror Heater"
       },
-      "back_left_door_is_locked": {
-        "name": "Back Left Door Lock"
+      "sleep_mode_check": {
+        "name": "Sleep Mode Check"
       },
-      "back_right_door_is_locked": {
-        "name": "Back Right Door Lock"
+      "smart_key_battery_warning_is_on": {
+        "name": "Smart Key Battery Warning"
       },
-      "ev_battery_winter_mode": {
-        "name": "EV Battery Winter Mode"
+      "steering_wheel_heater_is_on": {
+        "name": "Steering Wheel Heater"
+      },
+      "stop_lamp_left": {
+        "name": "Rear Left Lamp Fault"
+      },
+      "stop_lamp_right": {
+        "name": "Rear Right Lamp Fault"
+      },
+      "sunroof_is_open": {
+        "name": "Sunroof"
+      },
+      "tire_pressure_all_warning_is_on": {
+        "name": "Tire Pressure - All"
+      },
+      "tire_pressure_front_left_warning_is_on": {
+        "name": "Tire Pressure - Front Left"
+      },
+      "tire_pressure_front_right_warning_is_on": {
+        "name": "Tire Pressure - Front Right"
+      },
+      "tire_pressure_rear_left_warning_is_on": {
+        "name": "Tire Pressure - Rear Left"
+      },
+      "tire_pressure_rear_right_warning_is_on": {
+        "name": "Tire Pressure - Rear Right"
+      },
+      "transmission_condition": {
+        "name": "Transmission Condition"
+      },
+      "trunk_is_open": {
+        "name": "Trunk"
+      },
+      "turn_signal_left_front": {
+        "name": "Turn Signal Left Front"
+      },
+      "turn_signal_left_rear": {
+        "name": "Turn Signal Left Rear"
+      },
+      "turn_signal_right_front": {
+        "name": "Turn Signal Right Front"
+      },
+      "turn_signal_right_rear": {
+        "name": "Turn Signal Right Rear"
+      },
+      "washer_fluid_warning_is_on": {
+        "name": "Washer Fluid Warning"
       }
     },
     "lock": {


### PR DESCRIPTION
## Summary

Adds sensors for EV battery thermal management, outside temperature, and engine type identification.

### New sensors (3)

| Key | Translation key | Unit | Device class |
|---|---|---|---|
| `outside_temperature` | `outside_temperature` | Dynamic (°C/°F from API) | `TEMPERATURE` |
| `engine_type` | `engine_type` | — | Text sensor (EV/PHEV/HEV/IC) |
| `ev_battery_chiller_rpm` | `ev_battery_chiller_rpm` | RPM | — |

The `outside_temperature` sensor uses `DYNAMIC_UNIT` with the `_key` prefix convention (`_outside_temperature`), so HA resolves the unit from `Vehicle._outside_temperature_unit` at runtime — ensuring correct °F display for US users.

### New binary sensors (2)

| Key | Translation key |
|---|---|
| `ev_battery_precondition_enabled` | `ev_battery_precondition_enabled` |
| `ev_battery_heating_state` | `ev_battery_heating_state` |

All new entities use `getattr(vehicle, description.key, None) is not None` for conditional creation.

### Testing

Validated against live Hyundai EU API (Santa Fe HEV):
- `engine_type=ENGINE_TYPES.HEV` — engine type sensor works correctly
- Other thermal diagnostics (`ev_battery_chiller_rpm`, `ev_battery_precondition_enabled`, `ev_battery_heating_state`) are `None` on this HEV — correctly would not be created
- `outside_temperature` is `None` on this vehicle

Depends on: #1645 (CCS2 sensors — `ev_battery_chiller_rpm` is a thermal sensor)

## Test plan

- [ ] Install on EV vehicle and verify thermal diagnostic entities appear
- [ ] Verify `engine_type` shows correct type string (EV/PHEV/HEV/IC)
- [ ] Verify `outside_temperature` shows correct value with proper unit (°C or °F)
- [ ] Install on HEV vehicle and verify only `engine_type` entity appears