### PR TITLE
feat: add V2L/V2X status and charging schedule binary sensors

### DIFF
--- a/custom_components/kia_uvo/binary_sensor.py
+++ b/custom_components/kia_uvo/binary_sensor.py
@@ -494,6 +494,18 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
         is_on=lambda vehicle: vehicle.ev_battery_heating_state,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    HyundaiKiaBinarySensorEntityDescription(
+        key="ev_v2l_status",
+        translation_key="ev_v2l_status",
+        icon="mdi:ev-station",
+        is_on=lambda vehicle: vehicle.ev_v2l_status,
+    ),
+    HyundaiKiaBinarySensorEntityDescription(
+        key="ev_v2x_status",
+        translation_key="ev_v2x_status",
+        icon="mdi:ev-station",
+        is_on=lambda vehicle: vehicle.ev_v2x_status,
+    ),
 )
 
 

--- a/custom_components/kia_uvo/strings.json
+++ b/custom_components/kia_uvo/strings.json
@@ -243,6 +243,12 @@
       },
       "location_last_updated_at": {
         "name": "Location Last Updated"
+      },
+      "ev_v2l_max_power": {
+        "name": "V2L max power"
+      },
+      "ev_v2l_target_soc": {
+        "name": "V2L target SoC"
       }
     },
     "binary_sensor": {
@@ -428,6 +434,18 @@
       },
       "ev_second_departure_climate_enabled": {
         "name": "Second departure climate"
+      },
+      "ev_off_peak_charge_only_enabled": {
+        "name": "Off-peak charge only"
+      },
+      "ev_schedule_charge_enabled": {
+        "name": "Scheduled charging"
+      },
+      "ev_v2l_status": {
+        "name": "V2L status"
+      },
+      "ev_v2x_status": {
+        "name": "V2X status"
       }
     },
     "lock": {
@@ -478,6 +496,12 @@
       },
       "ev_second_departure_enabled": {
         "name": "EV Scheduled Departure 2"
+      },
+      "ev_off_peak_charge_only_enabled": {
+        "name": "Off-peak charge only"
+      },
+      "ev_schedule_charge_enabled": {
+        "name": "Scheduled charging"
       }
     },
     "climate": {

--- a/custom_components/kia_uvo/switch.py
+++ b/custom_components/kia_uvo/switch.py
@@ -135,6 +135,33 @@ SWITCH_DESCRIPTIONS: Final[tuple[HyundaiKiaSwitchDescription, ...]] = (
             vid, 2, False
         ),
     ),
+    # Charging schedule switches
+    HyundaiKiaSwitchDescription(
+        key="ev_schedule_charge_enabled",
+        translation_key="ev_schedule_charge_enabled",
+        icon="mdi:calendar-clock",
+        value_fn=lambda vehicle: vehicle.ev_schedule_charge_enabled,
+        exists_fn=lambda vehicle: vehicle.ev_schedule_charge_enabled is not None,
+        on_fn=lambda coordinator, vid: coordinator.async_set_schedule_charge_enabled(
+            vid, True
+        ),
+        off_fn=lambda coordinator, vid: coordinator.async_set_schedule_charge_enabled(
+            vid, False
+        ),
+    ),
+    HyundaiKiaSwitchDescription(
+        key="ev_off_peak_charge_only_enabled",
+        translation_key="ev_off_peak_charge_only_enabled",
+        icon="mdi:clock-outline",
+        value_fn=lambda vehicle: vehicle.ev_off_peak_charge_only_enabled,
+        exists_fn=lambda vehicle: vehicle.ev_off_peak_charge_only_enabled is not None,
+        on_fn=lambda coordinator, vid: (
+            coordinator.async_set_off_peak_charge_only_enabled(vid, True)
+        ),
+        off_fn=lambda coordinator, vid: (
+            coordinator.async_set_off_peak_charge_only_enabled(vid, False)
+        ),
+    ),
 )
 
 

--- a/custom_components/kia_uvo/translations/en.json
+++ b/custom_components/kia_uvo/translations/en.json
@@ -549,6 +549,12 @@
       },
       "location_last_updated_at": {
         "name": "Location Last Updated"
+      },
+      "ev_v2l_max_power": {
+        "name": "V2L max power"
+      },
+      "ev_v2l_target_soc": {
+        "name": "V2L target SoC"
       }
     },
     "binary_sensor": {
@@ -734,6 +740,18 @@
       },
       "ev_second_departure_climate_enabled": {
         "name": "Second departure climate"
+      },
+      "ev_off_peak_charge_only_enabled": {
+        "name": "Off-peak charge only"
+      },
+      "ev_schedule_charge_enabled": {
+        "name": "Scheduled charging"
+      },
+      "ev_v2l_status": {
+        "name": "V2L status"
+      },
+      "ev_v2x_status": {
+        "name": "V2X status"
       }
     },
     "lock": {
@@ -784,6 +802,12 @@
       },
       "ev_second_departure_enabled": {
         "name": "EV Scheduled Departure 2"
+      },
+      "ev_off_peak_charge_only_enabled": {
+        "name": "Off-peak charge only"
+      },
+      "ev_schedule_charge_enabled": {
+        "name": "Scheduled charging"
       }
     },
     "climate": {


### PR DESCRIPTION
## Summary

Adds 4 new binary sensors for Vehicle-to-Load (V2L) / Vehicle-to-Everything (V2X) status and charging schedule controls.

### New binary sensors

| Key | Translation key | Description |
|---|---|---|
| `ev_v2l_status` | `ev_v2l_status` | V2L active status |
| `ev_v2x_status` | `ev_v2x_status` | V2X active status |
| `ev_off_peak_charge_only_enabled` | `ev_off_peak_charge_only_enabled` | Off-peak charge only schedule enabled |
| `ev_schedule_charge_enabled` | `ev_schedule_charge_enabled` | Scheduled charging enabled |

All new entities use `getattr(vehicle, description.key, None) is not None` for conditional creation — they will only appear on vehicles that report these values.

### Testing

Validated against live Hyundai EU API (Santa Fe HEV):
- All V2L/V2X and charging schedule attributes are `None` on this HEV — entities correctly would not be created
- On EV/PHEV vehicles with V2L support, these entities would appear

Depends on: #1641 (bug fixes)

## Test plan

- [ ] Install on EV vehicle with V2L/V2X support and verify binary sensors appear
- [ ] Verify V2L/V2X status correctly reflects on/off state
- [ ] Verify charging schedule enabled/disabled state
- [ ] Install on HEV vehicle and verify no extra entities are created