### PR TITLE
fix: hide window cover entities for regions without window control

### DIFF
--- a/custom_components/kia_uvo/cover.py
+++ b/custom_components/kia_uvo/cover.py
@@ -68,6 +68,8 @@ async def async_setup_entry(
     entities = []
     for vehicle_id in coordinator.vehicle_manager.vehicles.keys():
         vehicle: Vehicle = coordinator.vehicle_manager.vehicles[vehicle_id]
+        if not coordinator.vehicle_manager.api.supports_window_control:
+            continue
         for description in COVER_DESCRIPTIONS:
             if getattr(vehicle, description.key, None) is not None:
                 entities.append(

--- a/custom_components/kia_uvo/cover.py
+++ b/custom_components/kia_uvo/cover.py
@@ -68,7 +68,7 @@ async def async_setup_entry(
     entities = []
     for vehicle_id in coordinator.vehicle_manager.vehicles.keys():
         vehicle: Vehicle = coordinator.vehicle_manager.vehicles[vehicle_id]
-        if not coordinator.vehicle_manager.api.supports_window_control:
+        if not vehicle.supports_window_control:
             continue
         for description in COVER_DESCRIPTIONS:
             if getattr(vehicle, description.key, None) is not None:


### PR DESCRIPTION
## Summary

- Skip creating window cover entities when `api.supports_window_control` is `False`
- Prevents `NotImplementedError` when USA/CA users try to use window covers

## Problem

Fixes #1655 — window cover entities appear for USA region vehicles because the USA API populates `front_left_window_is_open` etc. from vehicle status (read-only), but `set_windows_state` raises `NotImplementedError` when users try to control them.

## Solution

Check `coordinator.vehicle_manager.api.supports_window_control` before creating cover entities. When `False` (USA, CA), no window cover entities are created.

## Companion PR

Hyundai-Kia-Connect/hyundai_kia_connect_api#1128 — adds the `supports_window_control` flag to the API library