### PR TITLE
fix: update TrackerEntity and SourceType imports for HA 2026.6

### DIFF
--- a/custom_components/kia_uvo/device_tracker.py
+++ b/custom_components/kia_uvo/device_tracker.py
@@ -6,8 +6,8 @@ import logging
 
 from hyundai_kia_connect_api import Vehicle
 
-from homeassistant.components.device_tracker import SourceType
-from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.components.device_tracker import TrackerEntity
+from homeassistant.components.device_tracker.const import SourceType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback


### PR DESCRIPTION
## Summary

- Update `TrackerEntity` import from `homeassistant.components.device_tracker.config_entry` to `homeassistant.components.device_tracker`
- Update `SourceType` import from `homeassistant.components.device_tracker` to `homeassistant.components.device_tracker.const`

HA Core 2026.6 deprecated importing `TrackerEntity` and `SourceType` from `device_tracker.config_entry`. The old aliases will be removed in HA Core 2027.6.

Fixes #1687

## Test plan

- [ ] Verify no deprecation warning in HA 2026.6 logs
- [ ] Verify device_tracker entity still works (location updates)