### PR TITLE
fix: enable charging master flag when toggling departure schedule on

### DIFF
--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -440,6 +440,12 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
             options.first_departure.enabled = enabled
         else:
             options.second_departure.enabled = enabled
+        # reservFlag (charging_enabled) must be 1 for departure slots to take
+        # effect. If the vehicle doesn't expose ev_schedule_charge_enabled
+        # (None), the builder defaults it to False, causing the API to accept
+        # the request but ignore per-slot reservChargeSet.
+        if enabled and not options.charging_enabled:
+            options.charging_enabled = True
         await self.async_schedule_charging_and_climate(vehicle_id, options)
 
     async def async_set_departure_climate_enabled(


### PR DESCRIPTION
## Summary

When a vehicle doesn't expose `ev_schedule_charge_enabled` (returns `None`), `_build_schedule_options_from_vehicle` defaults it to `False`, which serializes to `reservFlag: 0` in the API payload. The Hyundai API accepts the request but ignores per-slot `reservChargeSet` when the master flag is off — making departure enable/disable a silent no-op.

The fix: when enabling a departure slot (`enabled=True`), force `charging_enabled` (reservFlag) to `True` if it's currently `False`. This ensures the master scheduled charging flag is set when a departure slot is activated, so the API actually processes the per-slot change.

Turning departure off does NOT automatically disable the master flag — that would be destructive if other departure slots are still active.

Fixes #1688

## Test plan

- [ ] Toggle EV Scheduled Departure 1 on → departure slot activates, car confirms schedule
- [ ] Toggle EV Scheduled Departure 1 off → departure slot deactivates
- [ ] Toggle EV Scheduled Departure 2 on → same behavior
- [ ] Vehicle with `ev_schedule_charge_enabled = None` → toggle should now work (was broken before)
- [ ] Vehicle with `ev_schedule_charge_enabled = True` → no change in behavior (master flag was already on)