### PR TITLE
feat: add DayTripInfoEntity for per-trip sensor data

### DIFF
--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -18,6 +18,7 @@ from hyundai_kia_connect_api import (
     ScheduleChargingClimateRequestOptions,
     Token,
 )
+from hyundai_kia_connect_api.const import ENGINE_TYPES
 from hyundai_kia_connect_api.exceptions import (
     AuthenticationError,
     UnsupportedControlError,
@@ -184,7 +185,10 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
         # a DEBUG log line rather than UpdateFailed.
         today_str = dt_util.now().strftime("%Y%m%d")
         for vehicle_id, vehicle in self.vehicle_manager.vehicles.items():
-            if vehicle.engine_type not in ("EV", "PHEV"):
+            # vehicle.engine_type holds an ENGINE_TYPES enum member, not a
+            # bare string — comparing against ("EV", "PHEV") would never
+            # match (typo silently filtered every vehicle out).
+            if vehicle.engine_type not in (ENGINE_TYPES.EV, ENGINE_TYPES.PHEV):
                 continue
             try:
                 await self.hass.async_add_executor_job(

--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -177,6 +177,28 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
                 self.vehicle_manager.update_all_vehicles_with_cached_state
             )
 
+        # Per-trip data (TRIP-01). The library implements update_day_trip_info()
+        # but the upstream coordinator never calls it. Trip data must not fail
+        # the coordinator update — wrap in try/except so a NoDataFound (5921),
+        # an unsupported region/firmware, or a transient backend error becomes
+        # a DEBUG log line rather than UpdateFailed.
+        today_str = dt_util.now().strftime("%Y%m%d")
+        for vehicle_id, vehicle in self.vehicle_manager.vehicles.items():
+            if vehicle.engine_type not in ("EV", "PHEV"):
+                continue
+            try:
+                await self.hass.async_add_executor_job(
+                    self.vehicle_manager.update_day_trip_info,
+                    vehicle_id,
+                    today_str,
+                )
+            except Exception as exc:
+                _LOGGER.debug(
+                    "Day trip info not available for vehicle %s (may be unsupported for this region/firmware): %s",
+                    vehicle_id,
+                    exc,
+                )
+
         return self.data
 
     async def async_update_all(self) -> None:

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/Hyundai-Kia-Connect/kia_uvo/issues",
   "loggers": ["kia_uvo", "hyundai_kia_connect_api"],
   "requirements": ["hyundai_kia_connect_api==4.14.1"],
-  "version": "3.2.0-trip.3"
+  "version": "3.2.0-trip.4"
 }

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/Hyundai-Kia-Connect/kia_uvo/issues",
   "loggers": ["kia_uvo", "hyundai_kia_connect_api"],
   "requirements": ["hyundai_kia_connect_api==4.14.1"],
-  "version": "3.2.0-trip.1"
+  "version": "3.2.0-trip.2"
 }

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/Hyundai-Kia-Connect/kia_uvo/issues",
   "loggers": ["kia_uvo", "hyundai_kia_connect_api"],
   "requirements": ["hyundai_kia_connect_api==4.14.1"],
-  "version": "3.2.0-trip.2"
+  "version": "3.2.0-trip.3"
 }

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/Hyundai-Kia-Connect/kia_uvo/issues",
   "loggers": ["kia_uvo", "hyundai_kia_connect_api"],
   "requirements": ["hyundai_kia_connect_api==4.14.1"],
-  "version": "3.2.0"
+  "version": "3.2.0-trip.1"
 }

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/Hyundai-Kia-Connect/kia_uvo/issues",
   "loggers": ["kia_uvo", "hyundai_kia_connect_api"],
   "requirements": ["hyundai_kia_connect_api==4.14.1"],
-  "version": "3.2.0-trip.5"
+  "version": "3.2.0-trip.6"
 }

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/Hyundai-Kia-Connect/kia_uvo/issues",
   "loggers": ["kia_uvo", "hyundai_kia_connect_api"],
   "requirements": ["hyundai_kia_connect_api==4.14.1"],
-  "version": "3.2.0-trip.4"
+  "version": "3.2.0-trip.5"
 }

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -612,6 +612,7 @@ class DayTripInfoEntity(SensorEntity, HyundaiKiaConnectEntity):
     """
 
     _attr_translation_key = "day_trip_info"
+    _attr_icon = "mdi:calendar"
 
     def __init__(self, coordinator, vehicle: Vehicle):
         super().__init__(coordinator, vehicle)

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -628,11 +628,12 @@ class DayTripInfoEntity(SensorEntity, HyundaiKiaConnectEntity):
         if self.vehicle.day_trip_info is None:
             return {}
         info = self.vehicle.day_trip_info
+        date_iso = _iso_date(info.yyyymmdd)
         return {
-            "yyyymmdd": info.yyyymmdd,
+            "date": date_iso,
             "trip_list": [
                 {
-                    "start_time": t.hhmmss,
+                    "start_time": _iso_datetime(date_iso, t.hhmmss),
                     "drive_time": t.drive_time,
                     "idle_time": t.idle_time,
                     "distance": t.distance,
@@ -646,3 +647,17 @@ class DayTripInfoEntity(SensorEntity, HyundaiKiaConnectEntity):
     @property
     def unique_id(self):
         return f"{DOMAIN}-day-trip-info-{self.vehicle.id}"
+
+
+def _iso_date(yyyymmdd):
+    """Convert YYYYMMDD packed string to ISO YYYY-MM-DD, or None if unset."""
+    if not yyyymmdd or len(yyyymmdd) != 8:
+        return None
+    return f"{yyyymmdd[0:4]}-{yyyymmdd[4:6]}-{yyyymmdd[6:8]}"
+
+
+def _iso_datetime(date_iso, hhmmss):
+    """Combine an ISO date with a packed HHMMSS string into ISO 8601."""
+    if not date_iso or not hhmmss or len(hhmmss) != 6:
+        return None
+    return f"{date_iso}T{hhmmss[0:2]}:{hhmmss[2:4]}:{hhmmss[4:6]}"

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -428,6 +428,14 @@ async def async_setup_entry(
         entities.append(
             VehicleEntity(coordinator, coordinator.vehicle_manager.vehicles[vehicle_id])
         )
+        # day_trip_info starts None and is populated by the coordinator's
+        # first update — register unconditionally so the entity exists even
+        # when no trip data has been fetched yet (TRIP-01).
+        entities.append(
+            DayTripInfoEntity(
+                coordinator, coordinator.vehicle_manager.vehicles[vehicle_id]
+            )
+        )
     async_add_entities(entities)
     return True
 
@@ -588,3 +596,52 @@ class TodaysDailyDrivingStatsEntity(SensorEntity, HyundaiKiaConnectEntity):
     @property
     def unique_id(self):
         return f"{DOMAIN}-todays-daily-driving-stats-{self.vehicle.id}"
+
+
+class DayTripInfoEntity(SensorEntity, HyundaiKiaConnectEntity):
+    """Per-trip sensor for today (TRIP-01).
+
+    State is the number of trips today; attributes carry the full per-trip list
+    (start time, drive/idle time, distance, avg/max speed). The underlying
+    ``vehicle.day_trip_info`` is populated by the coordinator on each cached-state
+    poll cycle via ``VehicleManager.update_day_trip_info()``; before the first
+    successful fetch (or when the trip endpoint is unsupported / returns
+    NoDataFound for this region/firmware) the value is ``None`` — both
+    ``state`` and ``state_attributes`` handle that case so the entity remains
+    available with state ``0`` instead of going unavailable.
+    """
+
+    _attr_translation_key = "day_trip_info"
+
+    def __init__(self, coordinator, vehicle: Vehicle):
+        super().__init__(coordinator, vehicle)
+
+    @property
+    def state(self):
+        if self.vehicle.day_trip_info is None:
+            return 0
+        return len(self.vehicle.day_trip_info.trip_list)
+
+    @property
+    def state_attributes(self):
+        if self.vehicle.day_trip_info is None:
+            return {}
+        info = self.vehicle.day_trip_info
+        return {
+            "yyyymmdd": info.yyyymmdd,
+            "trip_list": [
+                {
+                    "start_time": t.hhmmss,
+                    "drive_time": t.drive_time,
+                    "idle_time": t.idle_time,
+                    "distance": t.distance,
+                    "avg_speed": t.avg_speed,
+                    "max_speed": t.max_speed,
+                }
+                for t in info.trip_list
+            ],
+        }
+
+    @property
+    def unique_id(self):
+        return f"{DOMAIN}-day-trip-info-{self.vehicle.id}"

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from typing import Final
-from datetime import date
+from datetime import date, datetime, timedelta
 
 from hyundai_kia_connect_api import Vehicle
 
@@ -629,11 +629,24 @@ class DayTripInfoEntity(SensorEntity, HyundaiKiaConnectEntity):
             return {}
         info = self.vehicle.day_trip_info
         date_iso = _iso_date(info.yyyymmdd)
+        summary = info.summary
         return {
             "date": date_iso,
+            "summary": {
+                "drive_time": summary.drive_time,
+                "idle_time": summary.idle_time,
+                "distance": summary.distance,
+                "avg_speed": summary.avg_speed,
+                "max_speed": summary.max_speed,
+            }
+            if summary is not None
+            else None,
             "trip_list": [
                 {
                     "start_time": _iso_datetime(date_iso, t.hhmmss),
+                    "end_time": _iso_datetime_add(
+                        date_iso, t.hhmmss, (t.drive_time or 0) + (t.idle_time or 0)
+                    ),
                     "drive_time": t.drive_time,
                     "idle_time": t.idle_time,
                     "distance": t.distance,
@@ -661,3 +674,15 @@ def _iso_datetime(date_iso, hhmmss):
     if not date_iso or not hhmmss or len(hhmmss) != 6:
         return None
     return f"{date_iso}T{hhmmss[0:2]}:{hhmmss[2:4]}:{hhmmss[4:6]}"
+
+
+def _iso_datetime_add(date_iso, hhmmss, minutes):
+    """Return the naive ISO 8601 timestamp `minutes` after (date_iso, hhmmss)."""
+    start_iso = _iso_datetime(date_iso, hhmmss)
+    if start_iso is None:
+        return None
+    try:
+        start = datetime.fromisoformat(start_iso)
+    except (TypeError, ValueError):
+        return None
+    return (start + timedelta(minutes=int(minutes))).isoformat(timespec="seconds")

--- a/custom_components/kia_uvo/strings.json
+++ b/custom_components/kia_uvo/strings.json
@@ -97,6 +97,9 @@
       "daily_driving_stats": {
         "name": "Daily Driving Stats"
       },
+      "day_trip_info": {
+        "name": "Day Trip Info"
+      },
       "data": {
         "name": "Data"
       },

--- a/custom_components/kia_uvo/translations/en.json
+++ b/custom_components/kia_uvo/translations/en.json
@@ -403,6 +403,9 @@
       "daily_driving_stats": {
         "name": "Daily Driving Stats"
       },
+      "day_trip_info": {
+        "name": "Day Trip Info"
+      },
       "data": {
         "name": "Data"
       },


### PR DESCRIPTION
## Summary

Adds a new `DayTripInfoEntity` sensor exposing per-trip data for today, plus the coordinator wiring to populate it. The library (`hyundai_kia_connect_api`) already implements `update_day_trip_info()`, but the upstream coordinator never calls it, so the data is unreachable from HA. This PR closes that gap.

## What it adds

A single new sensor per vehicle (translation key `day_trip_info`, e.g. `sensor.<car>_day_trip_info`):

- **State** — integer trip count for today (`0` if no trips yet or endpoint unsupported, never `unavailable`).
- **Attributes**:
  - `date` — ISO `YYYY-MM-DD` for the day represented.
  - `summary` — day totals object: `drive_time`, `idle_time`, `distance`, `avg_speed`, `max_speed` (or `null` before the first successful fetch).
  - `trip_list` — list of per-trip dicts with `start_time` and `end_time` (naive ISO 8601 local), `drive_time`, `idle_time`, `distance`, `avg_speed`, `max_speed`.

## How it works

`coordinator.py` — in the cached-state branch of `_async_update_data()`, after the existing `update_all_vehicles_with_cached_state()` call:

- Compute `today_str = dt_util.now().strftime("%Y%m%d")` once.
- Loop over `self.vehicle_manager.vehicles.items()` and call `vehicle_manager.update_day_trip_info(vehicle_id, today_str)` for EV/PHEV vehicles only.
- The library call is synchronous → wrapped in `async_add_executor_job`.
- The full call is wrapped in `try/except Exception` with a DEBUG log so a `NoDataFound`, an unsupported region/firmware, or any transient backend error becomes a debug line, **not** an `UpdateFailed`. This protects integration availability — the per-trip endpoint is reportedly absent or flaky in some regions.

`sensor.py` — adds `DayTripInfoEntity(SensorEntity, HyundaiKiaConnectEntity)`:

- Registered unconditionally in `async_setup_entry` (one per vehicle). The entity is created at startup even when `vehicle.day_trip_info` is still `None` — otherwise users wouldn't see the sensor until the first successful fetch.
- `state` returns `len(trip_list)` when populated, else `0`.
- `state_attributes` returns `{}` when `day_trip_info` is `None`; otherwise the structure above.
- Times are emitted as naive ISO 8601 (`YYYY-MM-DDTHH:MM:SS`) — friendlier than the raw `YYYYMMDD`/`HHMMSS` strings the library returns.
- Icon: `mdi:calendar`.

`translations/en.json` — adds the `day_trip_info` translation entry.

## Engine-type gate (subtle bug to be aware of)

`vehicle.engine_type` is an `ENGINE_TYPES` enum member, not a string. Comparing it against the strings `"EV"` / `"PHEV"` silently filters every vehicle out. This PR imports `ENGINE_TYPES` from `hyundai_kia_connect_api.const` and compares against `ENGINE_TYPES.EV` / `ENGINE_TYPES.PHEV`.

## Testing

Verified on a real Hyundai Kona Electric (EU):

- Integration reloads cleanly; no `UpdateFailed` in HA logs.
- `sensor.<car>_day_trip_info` registered in the HA entity registry; state goes from `0` → positive integer as trips happen during the day.
- `start_time` / `end_time` render correctly in HA cards (the ISO-8601 conversion was necessary — the raw library strings were unfriendly).
- Tested both the empty-state path (car parked, `NoDataFound` from the endpoint → DEBUG line, sensor stays at `0`) and the populated path (after drives, attributes carry the full trip list and day summary).

## Notes for the maintainer

- `manifest.json` is bumped to a temporary fork-version (`3.2.0-trip.6`) used while iterating on a HACS custom repo. Happy to drop or rename it to whatever clean version you'd like to release this under.
- No new dependencies; all changes use existing library APIs.
