### PR TITLE
feat: add DayTripInfoEntity for per-trip sensor data

### DIFF
--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -178,6 +178,26 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
                 self.vehicle_manager.update_all_vehicles_with_cached_state
             )
 
+        # Per-trip data. The library implements update_day_trip_info() but the
+        # upstream coordinator never calls it. Trip data must not fail the
+        # coordinator update — wrap in try/except so a NoDataFound, an
+        # unsupported region/firmware, or a transient backend error becomes a
+        # DEBUG log line rather than UpdateFailed.
+        today_str = dt_util.now().strftime("%Y%m%d")
+        for vehicle_id in self.vehicle_manager.vehicles:
+            try:
+                await self.hass.async_add_executor_job(
+                    self.vehicle_manager.update_day_trip_info,
+                    vehicle_id,
+                    today_str,
+                )
+            except Exception as exc:
+                _LOGGER.debug(
+                    "Day trip info not available for vehicle %s: %s",
+                    vehicle_id,
+                    exc,
+                )
+
         return self.data
 
     async def async_update_all(self) -> None:

--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -65,6 +65,11 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
         """Initialize."""
         self.platforms: set[str] = set()
         self._action_lock = asyncio.Lock()
+        # Vehicle IDs where update_day_trip_info() returned without exception
+        # but left day_trip_info as None — indicates the base-class no-op ran,
+        # meaning the endpoint is not implemented for this region. Resets on
+        # HA restart so a firmware/API change is picked up on next boot.
+        self.day_trip_unsupported: set[str] = set()
 
         self.vehicle_manager = VehicleManager(
             region=config_entry.data.get(CONF_REGION),
@@ -178,22 +183,30 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
                 self.vehicle_manager.update_all_vehicles_with_cached_state
             )
 
-        # Per-trip data. The library implements update_day_trip_info() but the
-        # upstream coordinator never calls it. Trip data must not fail the
-        # coordinator update — wrap in try/except so a NoDataFound, an
-        # unsupported region/firmware, or a transient backend error becomes a
-        # DEBUG log line rather than UpdateFailed.
+        # Per-trip data for today. Skipped for vehicles where the endpoint is
+        # confirmed unsupported (see day_trip_unsupported). On exception the
+        # endpoint exists but returned no data (e.g. no trips yet) — keep
+        # polling. No exception but day_trip_info still None means the library's
+        # base-class no-op ran — endpoint unsupported, stop polling.
         today_str = dt_util.now().strftime("%Y%m%d")
         for vehicle_id in self.vehicle_manager.vehicles:
+            if vehicle_id in self.day_trip_unsupported:
+                continue
             try:
                 await self.hass.async_add_executor_job(
                     self.vehicle_manager.update_day_trip_info,
                     vehicle_id,
                     today_str,
                 )
+                if self.vehicle_manager.vehicles[vehicle_id].day_trip_info is None:
+                    self.day_trip_unsupported.add(vehicle_id)
+                    _LOGGER.debug(
+                        "Day trip info not supported for vehicle %s — skipping future polls",
+                        vehicle_id,
+                    )
             except Exception as exc:
                 _LOGGER.debug(
-                    "Day trip info not available for vehicle %s: %s",
+                    "Day trip info fetch failed for vehicle %s: %s",
                     vehicle_id,
                     exc,
                 )

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/Hyundai-Kia-Connect/kia_uvo/issues",
   "loggers": ["kia_uvo", "hyundai_kia_connect_api"],
   "requirements": ["hyundai_kia_connect_api==4.14.1"],
-  "version": "3.3.0"
+  "version": "3.3.0-trip.1"
 }

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -428,9 +428,6 @@ async def async_setup_entry(
         entities.append(
             VehicleEntity(coordinator, coordinator.vehicle_manager.vehicles[vehicle_id])
         )
-        # day_trip_info starts None and is populated by the coordinator's
-        # first update — register unconditionally so the entity exists even
-        # when no trip data has been fetched yet (TRIP-01).
         entities.append(
             DayTripInfoEntity(
                 coordinator, coordinator.vehicle_manager.vehicles[vehicle_id]
@@ -599,20 +596,22 @@ class TodaysDailyDrivingStatsEntity(SensorEntity, HyundaiKiaConnectEntity):
 
 
 class DayTripInfoEntity(SensorEntity, HyundaiKiaConnectEntity):
-    """Per-trip sensor for today (TRIP-01).
+    """Per-trip sensor for today.
 
     State is the number of trips today; attributes carry the full per-trip list
-    (start time, drive/idle time, distance, avg/max speed). The underlying
-    ``vehicle.day_trip_info`` is populated by the coordinator on each cached-state
-    poll cycle via ``VehicleManager.update_day_trip_info()``; before the first
-    successful fetch (or when the trip endpoint is unsupported / returns
-    NoDataFound for this region/firmware) the value is ``None`` — both
-    ``state`` and ``state_attributes`` handle that case so the entity remains
-    available with state ``0`` instead of going unavailable.
+    (start time, drive/idle time, distance, avg/max speed). ``vehicle.day_trip_info``
+    is populated by the coordinator each poll cycle; when it is ``None`` (unsupported
+    region/firmware or not yet fetched) state is ``0`` and attributes are empty.
+
+    Disabled by default — users enable it from the HA entity registry once they
+    confirm the trip endpoint works for their vehicle/region.
     """
 
     _attr_translation_key = "day_trip_info"
     _attr_icon = "mdi:calendar"
+    # Disabled by default: not all regions/firmware support the trip endpoint.
+    # Users who want trip tracking enable the entity from the HA UI.
+    _attr_entity_registry_enabled_default = False
 
     def __init__(self, coordinator, vehicle: Vehicle):
         super().__init__(coordinator, vehicle)

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -599,10 +599,13 @@ class DayTripInfoEntity(SensorEntity, HyundaiKiaConnectEntity):
     """Per-trip sensor for today.
 
     State is the number of trips today; attributes carry the full per-trip list
-    (start time, drive/idle time, distance, avg/max speed). ``vehicle.day_trip_info``
-    is populated by the coordinator each poll cycle; when it is ``None`` (unsupported
-    region/firmware or not yet fetched) state is ``0`` and attributes are empty —
-    same graceful-degradation pattern as ``DailyDrivingStatsEntity``.
+    (start time, drive/idle time, distance, avg/max speed).
+
+    Three possible states:
+    - ``unavailable`` — endpoint not supported for this vehicle/region (coordinator
+      confirmed by seeing no exception but day_trip_info still None after the call).
+    - ``0`` — endpoint supported, no trips recorded yet today.
+    - positive integer — number of trips driven today.
     """
 
     _attr_translation_key = "day_trip_info"
@@ -613,6 +616,8 @@ class DayTripInfoEntity(SensorEntity, HyundaiKiaConnectEntity):
 
     @property
     def state(self):
+        if self.vehicle.id in self.coordinator.day_trip_unsupported:
+            return None
         if self.vehicle.day_trip_info is None:
             return 0
         return len(self.vehicle.day_trip_info.trip_list)

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -601,17 +601,12 @@ class DayTripInfoEntity(SensorEntity, HyundaiKiaConnectEntity):
     State is the number of trips today; attributes carry the full per-trip list
     (start time, drive/idle time, distance, avg/max speed). ``vehicle.day_trip_info``
     is populated by the coordinator each poll cycle; when it is ``None`` (unsupported
-    region/firmware or not yet fetched) state is ``0`` and attributes are empty.
-
-    Disabled by default — users enable it from the HA entity registry once they
-    confirm the trip endpoint works for their vehicle/region.
+    region/firmware or not yet fetched) state is ``0`` and attributes are empty —
+    same graceful-degradation pattern as ``DailyDrivingStatsEntity``.
     """
 
     _attr_translation_key = "day_trip_info"
     _attr_icon = "mdi:calendar"
-    # Disabled by default: not all regions/firmware support the trip endpoint.
-    # Users who want trip tracking enable the entity from the HA UI.
-    _attr_entity_registry_enabled_default = False
 
     def __init__(self, coordinator, vehicle: Vehicle):
         super().__init__(coordinator, vehicle)

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from typing import Final
-from datetime import date
+from datetime import date, datetime, timedelta
 
 from hyundai_kia_connect_api import Vehicle
 
@@ -428,6 +428,14 @@ async def async_setup_entry(
         entities.append(
             VehicleEntity(coordinator, coordinator.vehicle_manager.vehicles[vehicle_id])
         )
+        # day_trip_info starts None and is populated by the coordinator's
+        # first update — register unconditionally so the entity exists even
+        # when no trip data has been fetched yet (TRIP-01).
+        entities.append(
+            DayTripInfoEntity(
+                coordinator, coordinator.vehicle_manager.vehicles[vehicle_id]
+            )
+        )
     async_add_entities(entities)
     return True
 
@@ -588,3 +596,93 @@ class TodaysDailyDrivingStatsEntity(SensorEntity, HyundaiKiaConnectEntity):
     @property
     def unique_id(self):
         return f"{DOMAIN}-todays-daily-driving-stats-{self.vehicle.id}"
+
+
+class DayTripInfoEntity(SensorEntity, HyundaiKiaConnectEntity):
+    """Per-trip sensor for today (TRIP-01).
+
+    State is the number of trips today; attributes carry the full per-trip list
+    (start time, drive/idle time, distance, avg/max speed). The underlying
+    ``vehicle.day_trip_info`` is populated by the coordinator on each cached-state
+    poll cycle via ``VehicleManager.update_day_trip_info()``; before the first
+    successful fetch (or when the trip endpoint is unsupported / returns
+    NoDataFound for this region/firmware) the value is ``None`` — both
+    ``state`` and ``state_attributes`` handle that case so the entity remains
+    available with state ``0`` instead of going unavailable.
+    """
+
+    _attr_translation_key = "day_trip_info"
+    _attr_icon = "mdi:calendar"
+
+    def __init__(self, coordinator, vehicle: Vehicle):
+        super().__init__(coordinator, vehicle)
+
+    @property
+    def state(self):
+        if self.vehicle.day_trip_info is None:
+            return 0
+        return len(self.vehicle.day_trip_info.trip_list)
+
+    @property
+    def state_attributes(self):
+        if self.vehicle.day_trip_info is None:
+            return {}
+        info = self.vehicle.day_trip_info
+        date_iso = _iso_date(info.yyyymmdd)
+        summary = info.summary
+        return {
+            "date": date_iso,
+            "summary": {
+                "drive_time": summary.drive_time,
+                "idle_time": summary.idle_time,
+                "distance": summary.distance,
+                "avg_speed": summary.avg_speed,
+                "max_speed": summary.max_speed,
+            }
+            if summary is not None
+            else None,
+            "trip_list": [
+                {
+                    "start_time": _iso_datetime(date_iso, t.hhmmss),
+                    "end_time": _iso_datetime_add(
+                        date_iso, t.hhmmss, (t.drive_time or 0) + (t.idle_time or 0)
+                    ),
+                    "drive_time": t.drive_time,
+                    "idle_time": t.idle_time,
+                    "distance": t.distance,
+                    "avg_speed": t.avg_speed,
+                    "max_speed": t.max_speed,
+                }
+                for t in info.trip_list
+            ],
+        }
+
+    @property
+    def unique_id(self):
+        return f"{DOMAIN}-day-trip-info-{self.vehicle.id}"
+
+
+def _iso_date(yyyymmdd):
+    """Convert YYYYMMDD packed string to ISO YYYY-MM-DD, or None if unset."""
+    if not yyyymmdd or len(yyyymmdd) != 8:
+        return None
+    return f"{yyyymmdd[0:4]}-{yyyymmdd[4:6]}-{yyyymmdd[6:8]}"
+
+
+def _iso_datetime(date_iso, hhmmss):
+    """Combine an ISO date with a packed HHMMSS string into ISO 8601."""
+    if not date_iso or not hhmmss or len(hhmmss) != 6:
+        return None
+    return f"{date_iso}T{hhmmss[0:2]}:{hhmmss[2:4]}:{hhmmss[4:6]}"
+
+
+def _iso_datetime_add(date_iso, hhmmss, minutes):
+    """Return the naive ISO 8601 timestamp `minutes` after (date_iso, hhmmss)."""
+    start_iso = _iso_datetime(date_iso, hhmmss)
+    if start_iso is None:
+        return None
+    try:
+        start = datetime.fromisoformat(start_iso)
+    except (TypeError, ValueError):
+        return None
+    return (start + timedelta(minutes=int(minutes))).isoformat(timespec="seconds")

--- a/custom_components/kia_uvo/strings.json
+++ b/custom_components/kia_uvo/strings.json
@@ -97,6 +97,9 @@
       "daily_driving_stats": {
         "name": "Daily Driving Stats"
       },
+      "day_trip_info": {
+        "name": "Day Trip Info"
+      },
       "data": {
         "name": "Data"
       },

--- a/custom_components/kia_uvo/translations/en.json
+++ b/custom_components/kia_uvo/translations/en.json
@@ -403,6 +403,9 @@
       "daily_driving_stats": {
         "name": "Daily Driving Stats"
       },
+      "day_trip_info": {
+        "name": "Day Trip Info"
+      },
       "data": {
         "name": "Data"
       },


### PR DESCRIPTION
## Summary

Adds a new `DayTripInfoEntity` sensor exposing per-trip data for today, plus the coordinator wiring to populate it. The library (`hyundai_kia_connect_api`) already implements `update_day_trip_info()`, but the upstream coordinator never calls it, so the data is unreachable from HA. This PR closes that gap.

## What it adds

A single new sensor per vehicle (translation key `day_trip_info`, e.g. `sensor.<car>_day_trip_info`):

- **State** — integer trip count for today, `0` if no trips yet, or `unavailable` if the endpoint is not supported for this vehicle/region.
- **Attributes**:
  - `date` — ISO `YYYY-MM-DD` for the day represented.
  - `summary` — day totals: `drive_time`, `idle_time`, `distance`, `avg_speed`, `max_speed` (or `null` before the first successful fetch).
  - `trip_list` — per-trip dicts with `start_time` / `end_time` (naive ISO 8601 local), `drive_time`, `idle_time`, `distance`, `avg_speed`, `max_speed`.

## How it works

`coordinator.py` — in the cached-state branch of `_async_update_data()`, after the existing `update_all_vehicles_with_cached_state()` call:

- Compute `today_str = dt_util.now().strftime("%Y%m%d")` once.
- Loop over `self.vehicle_manager.vehicles`, skipping any already marked unsupported (see below).
- Call `vehicle_manager.update_day_trip_info(vehicle_id, today_str)` for each via `async_add_executor_job`.
- **No exception, `day_trip_info` still `None`** — the library's base-class no-op ran; endpoint not implemented for this region. Vehicle is added to `coordinator.day_trip_unsupported` and skipped on all future polls (resets on HA restart).
- **Exception raised** (e.g. `NoDataFound`) — endpoint exists but returned no data (car parked, no trips yet). Logged at DEBUG; polling continues normally on the next cycle.

`sensor.py` — adds `DayTripInfoEntity(SensorEntity, HyundaiKiaConnectEntity)`:

- Registered unconditionally in `async_setup_entry` (one per vehicle).
- `state` returns `None` (unavailable) when the vehicle is in `coordinator.day_trip_unsupported`, `0` when `day_trip_info` is `None` but the endpoint is supported, or `len(trip_list)` when data is present.
- `state_attributes` returns `{}` when `day_trip_info` is `None`; otherwise the structure above.
- Times are emitted as naive ISO 8601 (`YYYY-MM-DDTHH:MM:SS`) — friendlier than the raw `YYYYMMDD`/`HHMMSS` strings the library returns.
- Icon: `mdi:calendar`.

`strings.json` / `translations/en.json` — adds the `day_trip_info` translation entry.

## Testing

Verified on a real Hyundai Kona Electric (EU):

- Integration reloads cleanly; no `UpdateFailed` in HA logs.
- `sensor.<car>_day_trip_info` registered in the HA entity registry; state goes from `0` → positive integer as trips happen during the day.
- `start_time` / `end_time` render correctly in HA cards (the ISO-8601 conversion was necessary — the raw library strings were unfriendly).
- Tested both the empty-state path (car parked, `NoDataFound` from the endpoint → DEBUG line, sensor stays at `0`) and the populated path (after drives, attributes carry the full trip list and day summary).

No new dependencies; all changes use existing library APIs.