### PR TITLE
fix: add BATTERY device_class to car_battery_percentage sensor

### DIFF
--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -70,6 +70,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         translation_key="car_battery_percentage",
         icon="mdi:car-battery",
         native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SensorEntityDescription(


### PR DESCRIPTION
## Summary

- Adds `device_class=SensorDeviceClass.BATTERY` to the `car_battery_percentage` sensor entity description

## Why

Without `SensorDeviceClass.BATTERY`, the 12V battery percentage sensor doesn't appear in Home Assistant's battery monitoring UI (Settings → Devices → Battery). The `ev_battery_percentage` and `ev_battery_soh_percentage` sensors already have this device class, but the ICE/hybrid 12V battery sensor was missing it.

Closes #1699

## Audit

I audited all sensors in `sensor.py` and `binary_sensor.py`. No other sensors were missing appropriate device_class values:
- `ev_battery_percentage` and `ev_battery_soh_percentage` already have `SensorDeviceClass.BATTERY`
- `ev_charging_current` correctly uses `SensorDeviceClass.POWER_FACTOR`
- `fuel_level` has no suitable device_class in HA (no `FUEL` device class exists)
- All other sensors either already have correct device_class or are percentage/numeric types without a matching class

## Test plan

- [x] Verified `ruff check` and `ruff format` pass
- [ ] Confirm `car_battery_percentage` entity now appears in HA battery monitoring UI