### PR TITLE
feat: add last_scanned_at sensor and debug polling config log

### DIFF
--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -113,6 +113,17 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
                 seconds=min(self.scan_interval, self.force_refresh_interval)
             ),
         )
+        _LOGGER.info(
+            "%s - Polling configured: scan_interval=%ds, "
+            "force_refresh_interval=%ds, update_interval=%ds, "
+            "no_force_refresh_hours=%d-%d",
+            DOMAIN,
+            self.scan_interval,
+            self.force_refresh_interval,
+            min(self.scan_interval, self.force_refresh_interval),
+            self.no_force_refresh_hour_start,
+            self.no_force_refresh_hour_finish,
+        )
 
     async def _async_update_data(self):
         """Update data via library. Called by update_coordinator periodically.
@@ -120,6 +131,12 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
         Allow to update for the first time without further checking
         Allow force update, if time diff between latest update and `now` is greater than force refresh delta
         """
+        _LOGGER.debug(
+            "%s - _async_update_data called, scan_interval=%ds, force_refresh_interval=%ds",
+            DOMAIN,
+            self.scan_interval,
+            self.force_refresh_interval,
+        )
         try:
             await self.async_check_and_refresh_token()
         except AuthenticationError as AuthError:

--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -113,7 +113,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
                 seconds=min(self.scan_interval, self.force_refresh_interval)
             ),
         )
-        _LOGGER.info(
+        _LOGGER.debug(
             "%s - Polling configured: scan_interval=%ds, "
             "force_refresh_interval=%ds, update_interval=%ds, "
             "no_force_refresh_hours=%d-%d",

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -81,6 +81,13 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SensorEntityDescription(
+        key="last_scanned_at",
+        translation_key="last_scanned_at",
+        icon="mdi:cloud-search",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    SensorEntityDescription(
         key="ev_battery_percentage",
         translation_key="ev_battery_percentage",
         native_unit_of_measurement=PERCENTAGE,

--- a/custom_components/kia_uvo/strings.json
+++ b/custom_components/kia_uvo/strings.json
@@ -187,6 +187,9 @@
       "last_updated_at": {
         "name": "Last Updated At"
       },
+      "last_scanned_at": {
+        "name": "Last Scanned At"
+      },
       "next_service_distance": {
         "name": "Next Service"
       },

--- a/custom_components/kia_uvo/translations/da.json
+++ b/custom_components/kia_uvo/translations/da.json
@@ -351,6 +351,9 @@
       "last_updated_at": {
         "name": "Last Updated At"
       },
+      "last_scanned_at": {
+        "name": "Sidste scanning"
+      },
       "ev_battery_percentage": {
         "name": "EV Battery Level"
       },

--- a/custom_components/kia_uvo/translations/de.json
+++ b/custom_components/kia_uvo/translations/de.json
@@ -245,6 +245,9 @@
       "last_updated_at": {
         "name": "Last Updated At"
       },
+      "last_scanned_at": {
+        "name": "Letzter Scan"
+      },
       "ev_battery_percentage": {
         "name": "EV Battery Level"
       },

--- a/custom_components/kia_uvo/translations/en.json
+++ b/custom_components/kia_uvo/translations/en.json
@@ -493,6 +493,9 @@
       "last_updated_at": {
         "name": "Last Updated At"
       },
+      "last_scanned_at": {
+        "name": "Last Scanned At"
+      },
       "next_service_distance": {
         "name": "Next Service"
       },

--- a/custom_components/kia_uvo/translations/es.json
+++ b/custom_components/kia_uvo/translations/es.json
@@ -246,6 +246,9 @@
       "last_updated_at": {
         "name": "Last Updated At"
       },
+      "last_scanned_at": {
+        "name": "Última exploración"
+      },
       "ev_battery_percentage": {
         "name": "EV Battery Level"
       },

--- a/custom_components/kia_uvo/translations/fi.json
+++ b/custom_components/kia_uvo/translations/fi.json
@@ -245,6 +245,9 @@
       "last_updated_at": {
         "name": "Last Updated At"
       },
+      "last_scanned_at": {
+        "name": "Viimeisin tarkistus"
+      },
       "ev_battery_percentage": {
         "name": "EV Battery Level"
       },

--- a/custom_components/kia_uvo/translations/fr.json
+++ b/custom_components/kia_uvo/translations/fr.json
@@ -231,6 +231,9 @@
       "last_updated_at": {
         "name": "Last Updated At"
       },
+      "last_scanned_at": {
+        "name": "Dernière interrogation"
+      },
       "ev_battery_percentage": {
         "name": "EV Battery Level"
       },

--- a/custom_components/kia_uvo/translations/hu.json
+++ b/custom_components/kia_uvo/translations/hu.json
@@ -245,6 +245,9 @@
       "last_updated_at": {
         "name": "Last Updated At"
       },
+      "last_scanned_at": {
+        "name": "Utolsó lekérdezés"
+      },
       "ev_battery_percentage": {
         "name": "EV Battery Level"
       },

--- a/custom_components/kia_uvo/translations/it.json
+++ b/custom_components/kia_uvo/translations/it.json
@@ -245,6 +245,9 @@
       "last_updated_at": {
         "name": "Last Updated At"
       },
+      "last_scanned_at": {
+        "name": "Ultimo aggiornamento server"
+      },
       "ev_battery_percentage": {
         "name": "EV Battery Level"
       },

--- a/custom_components/kia_uvo/translations/nb.json
+++ b/custom_components/kia_uvo/translations/nb.json
@@ -351,6 +351,9 @@
       "last_updated_at": {
         "name": "Last Updated At"
       },
+      "last_scanned_at": {
+        "name": "Siste skanning"
+      },
       "ev_battery_percentage": {
         "name": "EV Battery Level"
       },

--- a/custom_components/kia_uvo/translations/nl.json
+++ b/custom_components/kia_uvo/translations/nl.json
@@ -245,6 +245,9 @@
       "last_updated_at": {
         "name": "Last Updated At"
       },
+      "last_scanned_at": {
+        "name": "Laatste scan"
+      },
       "ev_battery_percentage": {
         "name": "EV Battery Level"
       },

--- a/custom_components/kia_uvo/translations/pl.json
+++ b/custom_components/kia_uvo/translations/pl.json
@@ -412,6 +412,9 @@
       "last_updated_at": {
         "name": "Ostatnia aktualizacja"
       },
+      "last_scanned_at": {
+        "name": "Ostatni skan"
+      },
       "ev_battery_percentage": {
         "name": "Poziom baterii EV"
       },

--- a/custom_components/kia_uvo/translations/sv.json
+++ b/custom_components/kia_uvo/translations/sv.json
@@ -351,6 +351,9 @@
       "last_updated_at": {
         "name": "Last Updated At"
       },
+      "last_scanned_at": {
+        "name": "Senaste skanning"
+      },
       "ev_battery_percentage": {
         "name": "EV Battery Level"
       },

--- a/custom_components/kia_uvo/translations/zh-Hans.json
+++ b/custom_components/kia_uvo/translations/zh-Hans.json
@@ -75,6 +75,9 @@
       "last_updated_at": {
         "name": "Last Updated At"
       },
+      "last_scanned_at": {
+        "name": "上次扫描"
+      },
       "ev_battery_percentage": {
         "name": "EV Battery Level"
       },


### PR DESCRIPTION
## Summary

Adds a `last_scanned_at` sensor showing when HA **actually polled the server**, and a debug log at startup showing the effective polling configuration.

### Problem

Users report `last_updated_at` updating every 30 min despite setting `scan_interval = 60 min` (kia_uvo#1718, kia_uvo#1553). The root cause is that `last_updated_at` uses `syncDate` from the API — a server-provided timestamp of when the **car last reported data**, not when HA made the request.

There is currently no way to distinguish:
1. HA is polling too often (misconfiguration)
2. The car reports new data between HA polls (normal telematics)

### Changes

**New sensor: `last_scanned_at`**
- Shows when HA actually polled the server (from `Vehicle.last_scanned_at`, set by the API library)
- `device_class: TIMESTAMP`, `entity_category: DIAGNOSTIC`, icon `mdi:cloud-search`
- Placed right after `last_updated_at` in sensor.py
- Translations added for all 13 languages

**Debug log: polling config at startup**
- Logs `scan_interval`, `force_refresh_interval`, `update_interval`, and `no_force_refresh_hours` when the coordinator initializes
- Makes it trivial to verify settings are applied correctly without digging through options

**Debug log: `_async_update_data` called**
- Logs each `_async_update_data` call with the current intervals
- Helps diagnose double-poll or overlapping cycle issues

### Depends on

- Hyundai-Kia-Connect/hyundai_kia_connect_api#1176 (adds `Vehicle.last_scanned_at` property)
- Manifest version must be bumped after that PR is merged and released

### Related

- kia_uvo#1718
- kia_uvo#1553
