### PR TITLE
fix: reload on options change

### DIFF
--- a/custom_components/kia_uvo/config_flow.py
+++ b/custom_components/kia_uvo/config_flow.py
@@ -150,7 +150,7 @@ async def validate_input(
         raise InvalidAuth from err
 
 
-class HyundaiKiaConnectOptionFlowHandler(config_entries.OptionsFlow):
+class HyundaiKiaConnectOptionFlowHandler(config_entries.OptionsFlowWithReload):
     """Handle an option flow for Hyundai / Kia Connect."""
 
     async def async_step_init(


### PR DESCRIPTION
As per options flow docs using the reload class to trigger a reload.  While we could use listeners I don't think worth the effort. 

Assists with #1718 

@blka  are you able to review for another set of eyes? 