### PR TITLE
ci: api dependency bump workflow with semantic commits

### DIFF
--- a/.github/workflows/bump-api-dependency.yml
+++ b/.github/workflows/bump-api-dependency.yml
@@ -23,13 +23,13 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Determine API bump
+      - name: Determine and apply API bump
         id: bump
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          python scripts/bump_api_dependency.py custom_components/kia_uvo/manifest.json --noop > bump_result.json
+          python scripts/bump_api_dependency.py custom_components/kia_uvo/manifest.json > bump_result.json
           cat bump_result.json
           echo "noop=$(jq -r '.noop' bump_result.json)" >> "$GITHUB_OUTPUT"
           echo "branch=$(jq -r '.branch' bump_result.json)" >> "$GITHUB_OUTPUT"
@@ -44,14 +44,6 @@ jobs:
           jq -r '.commit_body' bump_result.json > commit_body.md
           jq -r '.pr_body' bump_result.json > pr_body.md
 
-      - name: Apply manifest update
-        if: ${{ steps.bump.outputs.noop == 'false' }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          python scripts/bump_api_dependency.py custom_components/kia_uvo/manifest.json
-
       - name: Commit and push branch
         if: ${{ steps.bump.outputs.noop == 'false' }}
         run: |
@@ -60,9 +52,13 @@ jobs:
           git config --local user.name "GitHub Action"
           git checkout -B ${{ steps.bump.outputs.branch }}
           git add custom_components/kia_uvo/manifest.json
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 1
+          fi
           printf '%s\n\n' "${{ steps.bump.outputs.commit_title }}" > commit_msg.txt
           cat commit_body.md >> commit_msg.txt
-          git commit -F commit_msg.txt || true
+          git commit -F commit_msg.txt
           git push --force-with-lease origin ${{ steps.bump.outputs.branch }}
 
       - name: Create or update PR
@@ -71,7 +67,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          existing=$(gh pr list --head ${{ steps.bump.outputs.branch }} --state open --json number --jq '.[0].number')
+          existing=$(gh pr list --head ${{ steps.bump.outputs.branch }} --state open --json number --jq -r '.[0].number // empty')
           if [ -n "$existing" ]; then
             gh pr edit "$existing" --title "${{ steps.bump.outputs.pr_title }}" --body-file pr_body.md
           else

--- a/.github/workflows/bump-api-dependency.yml
+++ b/.github/workflows/bump-api-dependency.yml
@@ -41,6 +41,8 @@ jobs:
           echo "pr_body<<EOF" >> "$GITHUB_OUTPUT"
           jq -r '.pr_body' bump_result.json >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
+          jq -r '.commit_body' bump_result.json > commit_body.md
+          jq -r '.pr_body' bump_result.json > pr_body.md
 
       - name: Apply manifest update
         if: ${{ steps.bump.outputs.noop == 'false' }}
@@ -58,7 +60,9 @@ jobs:
           git config --local user.name "GitHub Action"
           git checkout -B ${{ steps.bump.outputs.branch }}
           git add custom_components/kia_uvo/manifest.json
-          git commit -m "${{ steps.bump.outputs.commit_title }}" -m "${{ steps.bump.outputs.commit_body }}" || true
+          printf '%s\n\n' "${{ steps.bump.outputs.commit_title }}" > commit_msg.txt
+          cat commit_body.md >> commit_msg.txt
+          git commit -F commit_msg.txt || true
           git push --force-with-lease origin ${{ steps.bump.outputs.branch }}
 
       - name: Create or update PR
@@ -69,7 +73,7 @@ jobs:
           set -euo pipefail
           existing=$(gh pr list --head ${{ steps.bump.outputs.branch }} --state open --json number --jq '.[0].number')
           if [ -n "$existing" ]; then
-            gh pr edit "$existing" --title "${{ steps.bump.outputs.pr_title }}" --body "${{ steps.bump.outputs.pr_body }}"
+            gh pr edit "$existing" --title "${{ steps.bump.outputs.pr_title }}" --body-file pr_body.md
           else
-            gh pr create --base master --head ${{ steps.bump.outputs.branch }} --title "${{ steps.bump.outputs.pr_title }}" --body "${{ steps.bump.outputs.pr_body }}"
+            gh pr create --base master --head ${{ steps.bump.outputs.branch }} --title "${{ steps.bump.outputs.pr_title }}" --body-file pr_body.md
           fi

--- a/.github/workflows/bump-api-dependency.yml
+++ b/.github/workflows/bump-api-dependency.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@8d9ed9ac5c53483e7b5f4efe10d6f4f806f6f183 # v5.5.0
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/bump-api-dependency.yml
+++ b/.github/workflows/bump-api-dependency.yml
@@ -1,0 +1,75 @@
+name: Bump API dependency
+
+on:
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump-api-dependency:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@8d9ed9ac5c53483e7b5f4efe10d6f4f806f6f183 # v5.5.0
+        with:
+          python-version: "3.12"
+
+      - name: Determine API bump
+        id: bump
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python scripts/bump_api_dependency.py custom_components/kia_uvo/manifest.json --noop > bump_result.json
+          cat bump_result.json
+          echo "noop=$(jq -r '.noop' bump_result.json)" >> "$GITHUB_OUTPUT"
+          echo "branch=$(jq -r '.branch' bump_result.json)" >> "$GITHUB_OUTPUT"
+          echo "commit_title=$(jq -r '.commit_title' bump_result.json)" >> "$GITHUB_OUTPUT"
+          echo "commit_body<<EOF" >> "$GITHUB_OUTPUT"
+          jq -r '.commit_body' bump_result.json >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "pr_title=$(jq -r '.pr_title' bump_result.json)" >> "$GITHUB_OUTPUT"
+          echo "pr_body<<EOF" >> "$GITHUB_OUTPUT"
+          jq -r '.pr_body' bump_result.json >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Apply manifest update
+        if: ${{ steps.bump.outputs.noop == 'false' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python scripts/bump_api_dependency.py custom_components/kia_uvo/manifest.json
+
+      - name: Commit and push branch
+        if: ${{ steps.bump.outputs.noop == 'false' }}
+        run: |
+          set -euo pipefail
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git checkout -B ${{ steps.bump.outputs.branch }}
+          git add custom_components/kia_uvo/manifest.json
+          git commit -m "${{ steps.bump.outputs.commit_title }}" -m "${{ steps.bump.outputs.commit_body }}" || true
+          git push --force-with-lease origin ${{ steps.bump.outputs.branch }}
+
+      - name: Create or update PR
+        if: ${{ steps.bump.outputs.noop == 'false' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          existing=$(gh pr list --head ${{ steps.bump.outputs.branch }} --state open --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh pr edit "$existing" --title "${{ steps.bump.outputs.pr_title }}" --body "${{ steps.bump.outputs.pr_body }}"
+          else
+            gh pr create --base master --head ${{ steps.bump.outputs.branch }} --title "${{ steps.bump.outputs.pr_title }}" --body "${{ steps.bump.outputs.pr_body }}"
+          fi

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices"]
+  "extends": ["config:best-practices"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["hyundai_kia_connect_api"],
+      "enabled": false
+    }
+  ]
 }

--- a/scripts/bump_api_dependency.py
+++ b/scripts/bump_api_dependency.py
@@ -178,7 +178,7 @@ def update_manifest(manifest_path: str, new_version: str) -> None:
 
 
 def main() -> int:
-    noop = "--noop" in sys.argv
+    dry_run = "--noop" in sys.argv
     args = [a for a in sys.argv[1:] if a != "--noop"]
     manifest_path = args[0] if args else "custom_components/kia_uvo/manifest.json"
     token = os.environ.get("GITHUB_TOKEN")
@@ -193,13 +193,13 @@ def main() -> int:
     commit_type, commit_body = classify_release_notes(releases)
     target_version = releases[-1]["tag_name"].lstrip("vV")
 
-    if not noop:
+    if not dry_run:
         update_manifest(manifest_path, target_version)
 
     commit_title = f"{_commit_prefix(commit_type)} bump {PACKAGE_NAME} {current_pin} → {target_version}"
 
     output = {
-        "noop": noop,
+        "noop": False,
         "branch": BRANCH_NAME,
         "commit_title": commit_title,
         "commit_body": commit_body,

--- a/scripts/bump_api_dependency.py
+++ b/scripts/bump_api_dependency.py
@@ -50,6 +50,63 @@ def _fetch_releases(owner: str, repo: str, token: str | None) -> list[dict[str, 
     return _http_get(url, token)
 
 
+def _fetch_compare(
+    owner: str, repo: str, base: str, head: str, token: str | None
+) -> dict[str, Any]:
+    url = f"https://api.github.com/repos/{owner}/{repo}/compare/{base}...{head}"
+    return _http_get(url, token)
+
+
+def _tag_name(version_or_tag: str) -> str:
+    return (
+        version_or_tag
+        if version_or_tag.lower().startswith("v")
+        else f"v{version_or_tag}"
+    )
+
+
+def _synthesize_body_from_commits(commits: list[dict[str, Any]]) -> str:
+    feat: list[str] = []
+    fix: list[str] = []
+    other: list[str] = []
+    breaking = False
+
+    for commit in commits:
+        message = commit.get("commit", {}).get("message", "").split("\n")[0].strip()
+        if not message:
+            continue
+        lower = message.lower()
+        if "breaking change" in lower or "breaking changes" in lower:
+            breaking = True
+        if lower.startswith("feat") or lower.startswith("fix"):
+            clean = re.sub(
+                r"^(feat|fix)(?:\([^)]+\))?!?:\s*", "", message, flags=re.IGNORECASE
+            )
+            (feat if lower.startswith("feat") else fix).append(clean)
+        else:
+            clean = re.sub(
+                r"^(chore|docs|ci|test)(?:\([^)]+\))?!?:\s*",
+                "",
+                message,
+                flags=re.IGNORECASE,
+            )
+            other.append(clean)
+
+    lines: list[str] = []
+    if breaking:
+        lines.append("BREAKING CHANGES")
+    if feat:
+        lines.append("### Features")
+        lines.extend(feat)
+    if fix:
+        lines.append("### Bug Fixes")
+        lines.extend(fix)
+    if not feat and not fix and other:
+        lines.append("### Other Changes")
+        lines.extend(other)
+    return "\n".join(lines)
+
+
 def list_releases_after(
     owner: str, repo: str, current_pin: str, token: str | None
 ) -> list[dict[str, Any]]:
@@ -88,7 +145,11 @@ def _classify_single_release(body: str) -> tuple[str, dict[str, list[str]]]:
     }
     level = "chore"
 
-    if re.search(r"BREAKING CHANGE", body, re.IGNORECASE):
+    if re.search(
+        r"BREAKING CHANGES?\b|^[#]+\s*BREAKING\b",
+        body,
+        re.IGNORECASE | re.MULTILINE,
+    ):
         level = "breaking"
         sections["breaking"].append("Release notes indicate a breaking change.")
 
@@ -101,6 +162,12 @@ def _classify_single_release(body: str) -> tuple[str, dict[str, list[str]]]:
     if fixes and fixes[0]:
         level = max(level, "fix", key=["chore", "fix", "feat", "breaking"].index)
         sections["fixes"].extend(fixes)
+
+    other = _extract_section(
+        body, ["### Other Changes", "## Other Changes"]
+    ).splitlines()
+    if other and other[0]:
+        sections["other"].extend(other)
 
     if not any(sections.values()):
         sections["other"].append("No categorized release notes.")
@@ -120,6 +187,10 @@ def _commit_prefix(level: str) -> str:
 
 def classify_release_notes(
     releases: list[dict[str, Any]],
+    current_pin: str,
+    owner: str = API_OWNER,
+    repo: str = API_REPO,
+    token: str | None = None,
 ) -> tuple[str, str]:
     aggregate: dict[str, list[str]] = {
         "breaking": [],
@@ -129,9 +200,16 @@ def classify_release_notes(
     }
     level = "chore"
 
-    for release in releases:
+    for i, release in enumerate(releases):
         tag = release["tag_name"].lstrip("vV")
         body = release.get("body") or ""
+        if not body.strip():
+            base = releases[i - 1]["tag_name"] if i > 0 else _tag_name(current_pin)
+            try:
+                compare = _fetch_compare(owner, repo, base, release["tag_name"], token)
+                body = _synthesize_body_from_commits(compare.get("commits", []))
+            except urllib.error.HTTPError:
+                body = ""
         rel_level, sections = _classify_single_release(body)
         if rel_level != "chore":
             level = max(
@@ -190,7 +268,9 @@ def main() -> int:
         print(json.dumps({"noop": True, "reason": "already at latest version"}))
         return 0
 
-    commit_type, commit_body = classify_release_notes(releases)
+    commit_type, commit_body = classify_release_notes(
+        releases, current_pin, API_OWNER, API_REPO, token
+    )
     target_version = releases[-1]["tag_name"].lstrip("vV")
 
     if not dry_run:

--- a/scripts/bump_api_dependency.py
+++ b/scripts/bump_api_dependency.py
@@ -178,9 +178,9 @@ def update_manifest(manifest_path: str, new_version: str) -> None:
 
 
 def main() -> int:
-    manifest_path = (
-        sys.argv[1] if len(sys.argv) > 1 else "custom_components/kia_uvo/manifest.json"
-    )
+    noop = "--noop" in sys.argv
+    args = [a for a in sys.argv[1:] if a != "--noop"]
+    manifest_path = args[0] if args else "custom_components/kia_uvo/manifest.json"
     token = os.environ.get("GITHUB_TOKEN")
 
     current_pin = get_current_pin(manifest_path)
@@ -192,12 +192,14 @@ def main() -> int:
 
     commit_type, commit_body = classify_release_notes(releases)
     target_version = releases[-1]["tag_name"].lstrip("vV")
-    update_manifest(manifest_path, target_version)
+
+    if not noop:
+        update_manifest(manifest_path, target_version)
 
     commit_title = f"{_commit_prefix(commit_type)} bump {PACKAGE_NAME} {current_pin} → {target_version}"
 
     output = {
-        "noop": False,
+        "noop": noop,
         "branch": BRANCH_NAME,
         "commit_title": commit_title,
         "commit_body": commit_body,

--- a/scripts/bump_api_dependency.py
+++ b/scripts/bump_api_dependency.py
@@ -1,0 +1,214 @@
+"""Helper to bump hyundai_kia_connect_api with semantic release notes."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+API_OWNER = "Hyundai-Kia-Connect"
+API_REPO = "hyundai_kia_connect_api"
+BRANCH_NAME = "chore/bump-api-dependency"
+PACKAGE_NAME = "hyundai_kia_connect_api"
+
+
+def _http_get(url: str, token: str | None) -> dict[str, Any]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def get_current_pin(manifest_path: str) -> str:
+    data = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+    for req in data.get("requirements", []):
+        match = re.search(rf"{re.escape(PACKAGE_NAME)}==([^\s\"]+)", req)
+        if match:
+            return match.group(1)
+    raise ValueError(f"{PACKAGE_NAME} not found in {manifest_path} requirements")
+
+
+def _version_key(tag: str) -> tuple[int, ...]:
+    clean = tag.lstrip("vV")
+    parts = clean.split(".")
+    return tuple(int(p) for p in parts[:3])
+
+
+def _fetch_releases(owner: str, repo: str, token: str | None) -> list[dict[str, Any]]:
+    url = f"https://api.github.com/repos/{owner}/{repo}/releases?per_page=100"
+    return _http_get(url, token)
+
+
+def list_releases_after(
+    owner: str, repo: str, current_pin: str, token: str | None
+) -> list[dict[str, Any]]:
+    releases = _fetch_releases(owner, repo, token)
+    current_key = _version_key(current_pin)
+    newer = [r for r in releases if _version_key(r["tag_name"]) > current_key]
+    return sorted(newer, key=lambda r: _version_key(r["tag_name"]))
+
+
+def _extract_section(body: str, headings: list[str]) -> str:
+    if not body:
+        return ""
+    lines = body.splitlines()
+    collected: list[str] = []
+    inside = False
+    for line in lines:
+        stripped = line.strip()
+        lower = stripped.lower()
+        if any(lower.startswith(h.lower()) for h in headings):
+            inside = True
+            continue
+        if inside and stripped.startswith("#"):
+            break
+        if inside and stripped:
+            collected.append(stripped)
+    return "\n".join(collected)
+
+
+def _classify_single_release(body: str) -> tuple[str, dict[str, list[str]]]:
+    body = body or ""
+    sections: dict[str, list[str]] = {
+        "breaking": [],
+        "features": [],
+        "fixes": [],
+        "other": [],
+    }
+    level = "chore"
+
+    if re.search(r"BREAKING CHANGE", body, re.IGNORECASE):
+        level = "breaking"
+        sections["breaking"].append("Release notes indicate a breaking change.")
+
+    features = _extract_section(body, ["### Features", "## Features"]).splitlines()
+    if features and features[0]:
+        level = max(level, "feat", key=["chore", "fix", "feat", "breaking"].index)
+        sections["features"].extend(features)
+
+    fixes = _extract_section(body, ["### Bug Fixes", "## Bug Fixes"]).splitlines()
+    if fixes and fixes[0]:
+        level = max(level, "fix", key=["chore", "fix", "feat", "breaking"].index)
+        sections["fixes"].extend(fixes)
+
+    if not any(sections.values()):
+        sections["other"].append("No categorized release notes.")
+
+    return level, sections
+
+
+def _commit_prefix(level: str) -> str:
+    if level == "breaking":
+        return "feat!(deps):"
+    if level == "feat":
+        return "feat(deps):"
+    if level == "fix":
+        return "fix(deps):"
+    return "chore(deps):"
+
+
+def classify_release_notes(
+    releases: list[dict[str, Any]],
+) -> tuple[str, str]:
+    aggregate: dict[str, list[str]] = {
+        "breaking": [],
+        "features": [],
+        "fixes": [],
+        "other": [],
+    }
+    level = "chore"
+
+    for release in releases:
+        tag = release["tag_name"].lstrip("vV")
+        body = release.get("body") or ""
+        rel_level, sections = _classify_single_release(body)
+        if rel_level != "chore":
+            level = max(
+                level, rel_level, key=["chore", "fix", "feat", "breaking"].index
+            )
+        for key in aggregate:
+            for item in sections.get(key, []):
+                aggregate[key].append(f"- {tag}: {item}")
+
+    first = releases[0]["tag_name"].lstrip("vV")
+    last = releases[-1]["tag_name"].lstrip("vV")
+    included = ", ".join(r["tag_name"].lstrip("vV") for r in releases)
+
+    body_lines = [
+        f"Bump `{PACKAGE_NAME}` from `{first}` to `{last}`.",
+        "",
+        f"Upstream versions included in this bump: {included}.",
+        "",
+    ]
+    if aggregate["breaking"]:
+        body_lines.extend(["### BREAKING CHANGES", *aggregate["breaking"], ""])
+    if aggregate["features"]:
+        body_lines.extend(["### Features", *aggregate["features"], ""])
+    if aggregate["fixes"]:
+        body_lines.extend(["### Bug Fixes", *aggregate["fixes"], ""])
+    if aggregate["other"]:
+        body_lines.extend(["### Other Changes", *aggregate["other"], ""])
+
+    return level, "\n".join(body_lines).rstrip()
+
+
+def update_manifest(manifest_path: str, new_version: str) -> None:
+    path = Path(manifest_path)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    requirements = data.get("requirements", [])
+    for i, req in enumerate(requirements):
+        if PACKAGE_NAME in req:
+            requirements[i] = f"{PACKAGE_NAME}=={new_version}"
+            break
+    else:
+        requirements.append(f"{PACKAGE_NAME}=={new_version}")
+    data["requirements"] = requirements
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    manifest_path = (
+        sys.argv[1] if len(sys.argv) > 1 else "custom_components/kia_uvo/manifest.json"
+    )
+    token = os.environ.get("GITHUB_TOKEN")
+
+    current_pin = get_current_pin(manifest_path)
+    releases = list_releases_after(API_OWNER, API_REPO, current_pin, token)
+
+    if not releases:
+        print(json.dumps({"noop": True, "reason": "already at latest version"}))
+        return 0
+
+    commit_type, commit_body = classify_release_notes(releases)
+    target_version = releases[-1]["tag_name"].lstrip("vV")
+    update_manifest(manifest_path, target_version)
+
+    commit_title = f"{_commit_prefix(commit_type)} bump {PACKAGE_NAME} {current_pin} → {target_version}"
+
+    output = {
+        "noop": False,
+        "branch": BRANCH_NAME,
+        "commit_title": commit_title,
+        "commit_body": commit_body,
+        "pr_title": commit_title,
+        "pr_body": commit_body,
+        "target_version": target_version,
+        "current_pin": current_pin,
+    }
+    print(json.dumps(output, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_bump_api_dependency.py
+++ b/tests/scripts/test_bump_api_dependency.py
@@ -27,12 +27,72 @@ def test_classify_release_notes_feat_and_fix():
         {"tag_name": "v4.22.0", "body": "### Features\n- add new sensor\n"},
         {"tag_name": "v4.23.0", "body": "### Bug Fixes\n- fix timeout\n"},
     ]
-    commit_type, body = classify_release_notes(releases)
+    commit_type, body = classify_release_notes(releases, "4.21.0")
     assert commit_type == "feat"
     assert "### Features" in body
     assert "- 4.22.0:" in body
     assert "### Bug Fixes" in body
     assert "- 4.23.0:" in body
+
+
+def test_classify_release_notes_breaking_heading():
+    releases = [
+        {
+            "tag_name": "v4.22.0",
+            "body": "### BREAKING CHANGES\n- drop legacy auth endpoint\n",
+        }
+    ]
+    commit_type, body = classify_release_notes(releases, "4.21.0")
+    assert commit_type == "breaking"
+    assert "### BREAKING CHANGES" in body
+    assert "- 4.22.0: Release notes indicate a breaking change." in body
+
+
+def test_classify_release_notes_empty_body_uses_compare_commits(monkeypatch):
+    releases = [{"tag_name": "v4.22.0", "body": ""}]
+
+    def _fetch_compare(_owner, _repo, base, head, _token):
+        assert base == "v4.21.0"
+        assert head == "v4.22.0"
+        return {
+            "commits": [
+                {"commit": {"message": "feat(api): add new sensor"}},
+                {"commit": {"message": "fix: resolve timeout issue"}},
+                {"commit": {"message": "chore: bump internal deps"}},
+            ]
+        }
+
+    monkeypatch.setattr("bump_api_dependency._fetch_compare", _fetch_compare)
+
+    commit_type, body = classify_release_notes(releases, "4.21.0")
+    assert commit_type == "feat"
+    assert "### Features" in body
+    assert "- 4.22.0: add new sensor" in body
+    assert "### Bug Fixes" in body
+    assert "- 4.22.0: resolve timeout issue" in body
+    assert "chore: bump internal deps" not in body
+
+
+def test_classify_release_notes_empty_body_falls_back_to_ignored_commits(monkeypatch):
+    releases = [{"tag_name": "v4.22.0", "body": "   "}]
+
+    def _fetch_compare(_owner, _repo, base, head, _token):
+        return {
+            "commits": [
+                {"commit": {"message": "chore: cleanup"}},
+                {"commit": {"message": "docs: update readme"}},
+                {"commit": {"message": "ci: tweak pipeline"}},
+                {"commit": {"message": "test: add coverage"}},
+            ]
+        }
+
+    monkeypatch.setattr("bump_api_dependency._fetch_compare", _fetch_compare)
+
+    commit_type, body = classify_release_notes(releases, "4.21.0")
+    assert commit_type == "chore"
+    assert "### Other Changes" in body
+    assert "- 4.22.0: cleanup" in body
+    assert "- 4.22.0: update readme" in body
 
 
 def test_update_manifest(tmp_path):

--- a/tests/scripts/test_bump_api_dependency.py
+++ b/tests/scripts/test_bump_api_dependency.py
@@ -1,0 +1,38 @@
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from bump_api_dependency import get_current_pin, classify_release_notes, update_manifest
+
+
+def test_get_current_pin(tmp_path):
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps({"requirements": ["hyundai_kia_connect_api==4.21.0"]})
+    )
+    assert get_current_pin(str(manifest)) == "4.21.0"
+
+
+def test_classify_release_notes_feat_and_fix():
+    releases = [
+        {"tag_name": "v4.22.0", "body": "### Features\n- add new sensor\n"},
+        {"tag_name": "v4.23.0", "body": "### Bug Fixes\n- fix timeout\n"},
+    ]
+    commit_type, body = classify_release_notes(releases)
+    assert commit_type == "feat"
+    assert "### Features" in body
+    assert "- 4.22.0:" in body
+    assert "### Bug Fixes" in body
+    assert "- 4.23.0:" in body
+
+
+def test_update_manifest(tmp_path):
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps({"requirements": ["hyundai_kia_connect_api==4.21.0"]})
+    )
+    update_manifest(str(manifest), "4.23.0")
+    data = json.loads(manifest.read_text())
+    assert data["requirements"] == ["hyundai_kia_connect_api==4.23.0"]

--- a/tests/scripts/test_bump_api_dependency.py
+++ b/tests/scripts/test_bump_api_dependency.py
@@ -81,7 +81,9 @@ def test_main_noop_does_not_change_manifest(
     assert data["requirements"] == ["hyundai_kia_connect_api==4.21.0"]
 
     captured = capsys.readouterr()
-    assert '"noop": true' in captured.out
+    # A bump is available, so the workflow signal is "noop": false; --noop only
+    # prevents writing the manifest.
+    assert '"noop": false' in captured.out
 
 
 def test_main_without_noop_changes_manifest(tmp_path, monkeypatch, fake_releases):
@@ -100,3 +102,29 @@ def test_main_without_noop_changes_manifest(tmp_path, monkeypatch, fake_releases
 
     data = json.loads(manifest.read_text())
     assert data["requirements"] == ["hyundai_kia_connect_api==4.22.0"]
+
+
+def test_main_at_latest_is_noop(tmp_path, monkeypatch, capsys):
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps({"requirements": ["hyundai_kia_connect_api==4.22.0"]})
+    )
+
+    def _no_new_releases(_owner, _repo, _token):
+        return []
+
+    monkeypatch.setattr("bump_api_dependency._fetch_releases", _no_new_releases)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["bump_api_dependency.py", str(manifest)],
+    )
+
+    assert main() == 0
+
+    data = json.loads(manifest.read_text())
+    assert data["requirements"] == ["hyundai_kia_connect_api==4.22.0"]
+
+    captured = capsys.readouterr()
+    assert '"noop": true' in captured.out
+    assert "already at latest version" in captured.out

--- a/tests/scripts/test_bump_api_dependency.py
+++ b/tests/scripts/test_bump_api_dependency.py
@@ -2,9 +2,16 @@ import json
 from pathlib import Path
 import sys
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
-from bump_api_dependency import get_current_pin, classify_release_notes, update_manifest
+from bump_api_dependency import (
+    classify_release_notes,
+    get_current_pin,
+    main,
+    update_manifest,
+)
 
 
 def test_get_current_pin(tmp_path):
@@ -36,3 +43,60 @@ def test_update_manifest(tmp_path):
     update_manifest(str(manifest), "4.23.0")
     data = json.loads(manifest.read_text())
     assert data["requirements"] == ["hyundai_kia_connect_api==4.23.0"]
+
+
+@pytest.fixture
+def fake_releases(monkeypatch):
+    def _fetch(_owner, _repo, _token):
+        return [
+            {
+                "tag_name": "v4.22.0",
+                "body": "### Features\n- new sensor\n",
+            }
+        ]
+
+    monkeypatch.setattr(
+        "bump_api_dependency._fetch_releases",
+        _fetch,
+    )
+
+
+def test_main_noop_does_not_change_manifest(
+    tmp_path, monkeypatch, fake_releases, capsys
+):
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps({"requirements": ["hyundai_kia_connect_api==4.21.0"]})
+    )
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["bump_api_dependency.py", str(manifest), "--noop"],
+    )
+
+    assert main() == 0
+
+    data = json.loads(manifest.read_text())
+    assert data["requirements"] == ["hyundai_kia_connect_api==4.21.0"]
+
+    captured = capsys.readouterr()
+    assert '"noop": true' in captured.out
+
+
+def test_main_without_noop_changes_manifest(tmp_path, monkeypatch, fake_releases):
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps({"requirements": ["hyundai_kia_connect_api==4.21.0"]})
+    )
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["bump_api_dependency.py", str(manifest)],
+    )
+
+    assert main() == 0
+
+    data = json.loads(manifest.read_text())
+    assert data["requirements"] == ["hyundai_kia_connect_api==4.22.0"]


### PR DESCRIPTION
This workflow replaces Renovate for the `hyundai_kia_connect_api` dependency bump.

What it does:
- Runs daily at 07:00 UTC.
- Reads the current pin from `custom_components/kia_uvo/manifest.json`.
- Fetches upstream GitHub releases and aggregates release notes for every version between the current pin and the latest release.
- Infers the conventional-commit type (`fix(deps):`, `feat(deps):`, or `feat!(deps):`) from upstream changes.
- Creates or updates a single rolling PR branch (`chore/bump-api-dependency`) so stale PRs do not pile up.
- Disables Renovate only for `hyundai_kia_connect_api` in `renovate.json`.

This lets the existing weekly `release.yml` detect a versionable commit and release `kia_uvo` when the API library changes.