### PR TITLE
fix: TypeError when in-car temperature is a non-numeric value

### DIFF
--- a/custom_components/kia_uvo/climate.py
+++ b/custom_components/kia_uvo/climate.py
@@ -110,16 +110,31 @@ class HyundaiKiaCarClimateControlSwitch(HyundaiKiaConnectEntity, ClimateEntity):
             return UnitOfTemperature(self.vehicle._air_temperature_unit)
         return UnitOfTemperature.CELSIUS
 
+    @staticmethod
+    def _as_float(value) -> float | None:
+        """Coerce a temperature value to float.
+
+        Some API backends (e.g. the US ones) report the in-car temperature as a
+        string such as "72" instead of a number. Home Assistant's climate base
+        class rejects non-numeric temperatures with a TypeError, so coerce here.
+        """
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
     @property
     def current_temperature(self) -> float | None:
         """Get the current in-car temperature."""
-        return self.vehicle.air_temperature
+        return self._as_float(self.vehicle.air_temperature)
 
     @property
     def target_temperature(self) -> float | None:
         """Get the desired in-car target temperature."""
         # TODO: use Coordinator data, not internal state
-        return self.climate_config.set_temp
+        return self._as_float(self.climate_config.set_temp)
 
     @property
     def target_temperature_step(self) -> float | None:


### PR DESCRIPTION
I noticed the climate entity periodically crashes the coordinator listener update with:

```
TypeError: Temperature is not a number: 72
  File ".../homeassistant/components/climate/__init__.py", line 355, in state_attributes
    ATTR_CURRENT_TEMPERATURE: show_temp(...)
  File ".../homeassistant/helpers/temperature.py", line 23, in display_temp
    raise TypeError(f"Temperature is not a number: {temperature}")
```

Home Assistant's climate base class passes `current_temperature`/`target_temperature` through `display_temp()`, which throws for any non-numeric value. I ran into this because the US backends (`KiaUvoApiUSA`, `HyundaiBlueLinkApiUSA`) set `vehicle.air_temperature` without casting, unlike the EU/other backends, which use `float(air_temp)`). So for US vehicles the string flows into `display_temp()` and crashes the listener update on every coordinator refresh.

## Fix

This PR coerces the temperature values to `float` in the climate entity and returns `None` for missing or non-numeric values. It also corrects the `hvac_mode` / `hvac_action` comparisons, which previously compared values lexically as strings (e.g. `"72" > "70"`).

## Testing

I tested on my local Home Assistant instance with a US Kia Telluride and confirmed `climate.*_climate_control` reports `current_temperature` / `temperature` as numbers and no `TypeError` appears in the logs.