### PR TITLE
fix: valet switch AttributeError crashing the entire switch platform

### DIFF
--- a/custom_components/kia_uvo/switch.py
+++ b/custom_components/kia_uvo/switch.py
@@ -175,8 +175,9 @@ SWITCH_DESCRIPTIONS: Final[tuple[HyundaiKiaSwitchDescription, ...]] = (
         key="valet_mode_control",
         translation_key="valet_mode_control",
         icon="mdi:key-variant",
-        value_fn=lambda vehicle: vehicle.valet_mode_active,
-        exists_fn=lambda vehicle: vehicle.valet_mode_active is not None,
+        value_fn=lambda vehicle: getattr(vehicle, "valet_mode_active", None),
+        exists_fn=lambda vehicle: getattr(vehicle, "valet_mode_active", None)
+        is not None,
         on_fn=lambda coordinator, vid: coordinator.async_start_valet_mode(vid),
         off_fn=lambda coordinator, vid: coordinator.async_stop_valet_mode(vid),
     ),

--- a/custom_components/kia_uvo/switch.py
+++ b/custom_components/kia_uvo/switch.py
@@ -176,8 +176,9 @@ SWITCH_DESCRIPTIONS: Final[tuple[HyundaiKiaSwitchDescription, ...]] = (
         translation_key="valet_mode_control",
         icon="mdi:key-variant",
         value_fn=lambda vehicle: getattr(vehicle, "valet_mode_active", None),
-        exists_fn=lambda vehicle: getattr(vehicle, "valet_mode_active", None)
-        is not None,
+        exists_fn=lambda vehicle: (
+            getattr(vehicle, "valet_mode_active", None) is not None
+        ),
         on_fn=lambda coordinator, vid: coordinator.async_start_valet_mode(vid),
         off_fn=lambda coordinator, vid: coordinator.async_stop_valet_mode(vid),
     ),


### PR DESCRIPTION
## Problem

On startup the switch platform fails to set up with:

```
ERROR (MainThread) [homeassistant.components.switch] Error while setting up kia_uvo platform for switch: 'Vehicle' object has no attribute 'valet_mode_active'
  File ".../custom_components/kia_uvo/switch.py", line 179, in <lambda>
  File ".../custom_components/kia_uvo/switch.py", line 196, in async_setup_entry
```

The `valet_mode_control` switch (added in #1647) reads `vehicle.valet_mode_active` in its `exists_fn`/`value_fn`:

```python
value_fn=lambda vehicle: vehicle.valet_mode_active,
exists_fn=lambda vehicle: vehicle.valet_mode_active is not None,
```

However `hyundai_kia_connect_api` does **not** expose a `valet_mode_active` attribute on `Vehicle` — it is absent in `4.21.0` (the version pinned in `manifest.json`, and the latest release) and is not present on the library's `master` branch either. The library has the valet *action* methods (`start_valet_mode` / `stop_valet_mode`) but no valet *state* attribute to back a switch.

Because `exists_fn` is evaluated for every vehicle inside `async_setup_entry`, the resulting `AttributeError` propagates out and **aborts setup of the entire switch platform** — so none of the kia_uvo switches are created, and previously-created ones (e.g. the climate switch) go `unavailable`.

## Fix

Use `getattr(vehicle, "valet_mode_active", None)` so the switch reports it does not exist (rather than raising) when the library lacks the attribute. Other switches set up normally, and the valet switch will start appearing automatically once a library version that provides `valet_mode_active` is installed.

## Testing

Reproduced on a live Home Assistant instance (US Kia Telluride, library 4.21.0): before the fix the switch platform failed to set up and `switch.*_climate` was `unavailable`; after the fix the platform sets up cleanly, `switch.*_climate` returns to `off`, and no `AttributeError` appears in the logs.