### PR TITLE
fix(button): guard window buttons with supports_window_control

### DIFF
--- a/custom_components/kia_uvo/button.py
+++ b/custom_components/kia_uvo/button.py
@@ -54,21 +54,30 @@ BUTTON_DESCRIPTIONS: Final[tuple[HyundaiKiaButtonDescription, ...]] = (
         translation_key="open_all_windows",
         icon="mdi:window-maximize",
         press_action="async_open_all_windows",
-        exists_fn=lambda vehicle: vehicle.front_left_window_is_open is not None,
+        exists_fn=lambda vehicle: (
+            vehicle.supports_window_control
+            and vehicle.front_left_window_is_open is not None
+        ),
     ),
     HyundaiKiaButtonDescription(
         key="close_all_windows",
         translation_key="close_all_windows",
         icon="mdi:window-minimize",
         press_action="async_close_all_windows",
-        exists_fn=lambda vehicle: vehicle.front_left_window_is_open is not None,
+        exists_fn=lambda vehicle: (
+            vehicle.supports_window_control
+            and vehicle.front_left_window_is_open is not None
+        ),
     ),
     HyundaiKiaButtonDescription(
         key="vent_all_windows",
         translation_key="vent_all_windows",
         icon="mdi:window-open-variant",
         press_action="async_vent_all_windows",
-        exists_fn=lambda vehicle: vehicle.front_left_window_is_open is not None,
+        exists_fn=lambda vehicle: (
+            vehicle.supports_window_control
+            and vehicle.front_left_window_is_open is not None
+        ),
     ),
 )
 


### PR DESCRIPTION
Fixes #1750

Guards `open_all_windows`, `close_all_windows`, and `vent_all_windows` buttons behind `vehicle.supports_window_control`, so they are only exposed for vehicles that actually support window control.

Valet-related changes have been moved to a separate branch (`feature/valet-mode-buttons`) to keep this PR focused.