### PR TITLE
fix(sensor): use EV battery instead of 12V on device info page

### DIFF
--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -72,6 +72,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SensorEntityDescription(
         key="last_updated_at",


### PR DESCRIPTION
Fixes #1749.

Marks `car_battery_percentage` sensor with `EntityCategory.DIAGNOSTIC` so Home Assistant no longer picks the 12 V battery as the device's battery indicator. For EVs, the device page will now show the EV battery level sensor instead.