### PR TITLE
feat(valet): add start/stop buttons and guard switch by capability

### DIFF
--- a/custom_components/kia_uvo/button.py
+++ b/custom_components/kia_uvo/button.py
@@ -50,6 +50,20 @@ BUTTON_DESCRIPTIONS: Final[tuple[HyundaiKiaButtonDescription, ...]] = (
         enabled_fn=lambda _: False,
     ),
     HyundaiKiaButtonDescription(
+        key="start_valet_mode",
+        translation_key="start_valet_mode",
+        icon="mdi:key-variant",
+        press_action="async_start_valet_mode",
+        exists_fn=lambda vehicle: vehicle.supports_valet_mode,
+    ),
+    HyundaiKiaButtonDescription(
+        key="stop_valet_mode",
+        translation_key="stop_valet_mode",
+        icon="mdi:key-variant",
+        press_action="async_stop_valet_mode",
+        exists_fn=lambda vehicle: vehicle.supports_valet_mode,
+    ),
+    HyundaiKiaButtonDescription(
         key="open_all_windows",
         translation_key="open_all_windows",
         icon="mdi:window-maximize",

--- a/custom_components/kia_uvo/strings.json
+++ b/custom_components/kia_uvo/strings.json
@@ -478,6 +478,12 @@
       "start_hazard_lights_and_horn": {
         "name": "Start Hazard Lights and Horn"
       },
+      "start_valet_mode": {
+        "name": "Start Valet Mode"
+      },
+      "stop_valet_mode": {
+        "name": "Stop Valet Mode"
+      },
       "open_all_windows": {
         "name": "Open All Windows"
       },

--- a/custom_components/kia_uvo/switch.py
+++ b/custom_components/kia_uvo/switch.py
@@ -176,7 +176,9 @@ SWITCH_DESCRIPTIONS: Final[tuple[HyundaiKiaSwitchDescription, ...]] = (
         translation_key="valet_mode_control",
         icon="mdi:key-variant",
         value_fn=lambda vehicle: vehicle.valet_mode_active,
-        exists_fn=lambda vehicle: vehicle.valet_mode_active is not None,
+        exists_fn=lambda vehicle: (
+            vehicle.supports_valet_mode and vehicle.valet_mode_active is not None
+        ),
         on_fn=lambda coordinator, vid: coordinator.async_start_valet_mode(vid),
         off_fn=lambda coordinator, vid: coordinator.async_stop_valet_mode(vid),
     ),

--- a/custom_components/kia_uvo/translations/en.json
+++ b/custom_components/kia_uvo/translations/en.json
@@ -784,6 +784,12 @@
       "start_hazard_lights_and_horn": {
         "name": "Start Hazard Lights and Horn"
       },
+      "start_valet_mode": {
+        "name": "Start Valet Mode"
+      },
+      "stop_valet_mode": {
+        "name": "Stop Valet Mode"
+      },
       "open_all_windows": {
         "name": "Open All Windows"
       },

--- a/custom_components/kia_uvo/translations/pl.json
+++ b/custom_components/kia_uvo/translations/pl.json
@@ -675,6 +675,27 @@
     "button": {
       "force_refresh": {
         "name": "Wymuś odświeżenie"
+      },
+      "start_hazard_lights": {
+        "name": "Włącz światła awaryjne"
+      },
+      "start_hazard_lights_and_horn": {
+        "name": "Włącz światła awaryjne i klakson"
+      },
+      "start_valet_mode": {
+        "name": "Włącz tryb valet"
+      },
+      "stop_valet_mode": {
+        "name": "Wyłącz tryb valet"
+      },
+      "open_all_windows": {
+        "name": "Otwórz wszystkie okna"
+      },
+      "close_all_windows": {
+        "name": "Zamknij wszystkie okna"
+      },
+      "vent_all_windows": {
+        "name": "Wentyluj wszystkie okna"
       }
     },
     "switch": {


### PR DESCRIPTION
This PR adds valet mode control as button entities and tightens the existing valet switch guard.

Requires: Hyundai-Kia-Connect/hyundai_kia_connect_api#1207 (merged)

Changes:
- Add `start_valet_mode` and `stop_valet_mode` button entities.
- Guard the valet switch behind `vehicle.supports_valet_mode AND vehicle.valet_mode_active is not None`, so the switch only shows where both capability and status are available.
- Add translation keys for the new buttons.
- Complete Polish translations for existing hazard-lights buttons.

Why buttons + switch instead of just a switch:
- A Home Assistant switch needs a reliable current state (on/off) from `vehicle.valet_mode_active`.
- EU CCS2 does not expose valet status in the cached-state response, so EU users would not see a valet switch at all.
- Buttons are one-shot actions: they don't need the current state, only the capability flag (`supports_valet_mode`).
- The switch remains available for regions that do report valet status; buttons cover the rest.

This separates the valet work from #1759, which is now focused only on the window-button regression.