### PR TITLE
fix(ci): correct gh pr list jq syntax in bump workflow

### DIFF
--- a/.github/workflows/bump-api-dependency.yml
+++ b/.github/workflows/bump-api-dependency.yml
@@ -67,7 +67,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          existing=$(gh pr list --head ${{ steps.bump.outputs.branch }} --state open --json number --jq -r '.[0].number // empty')
+          existing=$(gh pr list --head ${{ steps.bump.outputs.branch }} --state open --json number --jq '.[0].number // empty')
           if [ -n "$existing" ]; then
             gh pr edit "$existing" --title "${{ steps.bump.outputs.pr_title }}" --body-file pr_body.md
           else


### PR DESCRIPTION
Follow-up to #1746. The bump workflow's Create or update PR step failed with `unknown argument ".[0].number // empty"` because `gh pr list --jq -r '.[0].number // empty'` is invalid — gh CLI has no `-r` flag, so `--jq` consumed `-r` as its expression and the rest split into unknown arguments.

Effect: when a new upstream API release was detected (e.g. 4.22.0), the workflow committed the manifest bump and pushed `chore/bump-api-dependency`, but the PR step failed, so no PR was opened. The branch is left on master without a PR.

Fix: drop `-r` so `--jq` receives the full expression as one quoted argument.

Verified locally:
- `gh pr list --head chore/bump-api-dependency --state open --json number --jq '.[0].number // empty'` returns empty (exit 0) when no PR exists,
- returns the PR number (exit 0) when one exists.

Follow-up suggested: the orphan `chore/bump-api-dependency` branch currently on upstream master should be deleted (or merged manually) so the next workflow run starts clean.