### PR TITLE
fix(ci): actually disable Renovate for hyundai_kia_connect_api + fix bump body from-version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
   "extends": ["config:best-practices"],
   "packageRules": [
     {
-      "matchPackageNames": ["hyundai_kia_connect_api"],
+      "description": "Disable Renovate for hyundai_kia_connect_api; the kia_uvo bump-api-dependency workflow handles this pin with semantic release notes. matchDepNames matches the depName as written in manifest.json (matchPackageNames would match the pypi packageName with dashes and miss).",
+      "matchDepNames": ["hyundai_kia_connect_api"],
       "enabled": false
     }
   ]

--- a/scripts/bump_api_dependency.py
+++ b/scripts/bump_api_dependency.py
@@ -219,12 +219,11 @@ def classify_release_notes(
             for item in sections.get(key, []):
                 aggregate[key].append(f"- {tag}: {item}")
 
-    first = releases[0]["tag_name"].lstrip("vV")
     last = releases[-1]["tag_name"].lstrip("vV")
     included = ", ".join(r["tag_name"].lstrip("vV") for r in releases)
 
     body_lines = [
-        f"Bump `{PACKAGE_NAME}` from `{first}` to `{last}`.",
+        f"Bump `{PACKAGE_NAME}` from `{current_pin}` to `{last}`.",
         "",
         f"Upstream versions included in this bump: {included}.",
         "",

--- a/tests/scripts/test_bump_api_dependency.py
+++ b/tests/scripts/test_bump_api_dependency.py
@@ -35,6 +35,15 @@ def test_classify_release_notes_feat_and_fix():
     assert "- 4.23.0:" in body
 
 
+def test_classify_release_notes_body_uses_current_pin_as_from():
+    # Single skipped release: body must read "from <current_pin> to <last>",
+    # not "from <last> to <last>" (regression guard for the "from" field).
+    releases = [{"tag_name": "v4.22.1", "body": "### Bug Fixes\n- fix a bug\n"}]
+    _commit_type, body = classify_release_notes(releases, "4.22.0")
+    assert "from `4.22.0` to `4.22.1`" in body
+    assert "from `4.22.1` to `4.22.1`" not in body
+
+
 def test_classify_release_notes_breaking_heading():
     releases = [
         {


### PR DESCRIPTION
Follow-up to #1746 / #1766. Two issues found after the bump-api-dependency workflow was merged.

## 1. Renovate is still opening `chore(deps)` PRs despite `enabled: false`

`renovate.json` disabled `hyundai_kia_connect_api` with:

```json
{"matchPackageNames": ["hyundai_kia_connect_api"], "enabled": false}
```

but Renovate still opened #1768 (`chore(deps): update dependency hyundai_kia_connect_api to v4.22.1`) after this config was on `master`.

**Root cause:** the `homeassistant-manifest` manager extracts two names:

| field | value |
|---|---|
| `depName` | `hyundai_kia_connect_api` (underscores, as written in `manifest.json`) |
| `packageName` | `hyundai-kia-connect-api` (dashes, pypi canonical) |
| `datasource` | `pypi` |

`matchPackageNames` matches `packageName` (dashes), not `depName` (underscores). Our rule used the underscore form, so it never matched and `enabled: false` was never applied.

**Fix:** switch to `matchDepNames`, which matches `depName` as written in the manifest. Added a `description` explaining why.

**Verified** with a local Renovate dry-run (`--platform local`, reading the updated `renovate.json`):

```
DEBUG: Dependency: hyundai_kia_connect_api, is disabled (repository=local)
"homeassistant-manifest": {"fileCount": 1, "depCount": 1}   # extract
"homeassistant-manifest": 0                                   # updates after rule applied
DEBUG: 2 flattened updates found: mcr.microsoft.com/vscode/devcontainers/python, mcr.microsoft.com/vscode/devcontainers/python
```

The old rule instead produced `Would commit files to branch renovate/hyundai_kia_connect_api-4.x`.

After merge, Renovate will stop opening **new** bump PRs for this dependency. The already-open #1768 will remain until a maintainer closes/merges it.

## 2. Bump body reads `from X to X` instead of `from <current_pin> to X`

`classify_release_notes` built the PR/commit body as:

```python
first = releases[0]["tag_name"].lstrip("vV")
...
f"Bump `{PACKAGE_NAME}` from `{first}` to `{last}`."
```

`first` was the first **newer** release, not `current_pin`. For a single skipped release (the common case: one API release between daily runs) this produced `Bump hyundai_kia_connect_api from 4.22.1 to 4.22.1.` — misleading. The `commit_title` and the manifest bump already used `current_pin -> target_version` correctly, so this is display-only.

**Fix:** use `current_pin` for the `from` field. Adds a regression test (`test_classify_release_notes_body_uses_current_pin_as_from`).

## Out of scope (still blocking the workflow)

The bump workflow itself still cannot open its PR. Run 07-01 15:14 UTC (manual `workflow_dispatch` after #1766 merged) failed with:

```
pull request create failed: GraphQL: GitHub Actions is not permitted
to create or approve pull requests (createPullRequest)
```

This is a repository setting, not a code issue: **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** must be enabled. Only a maintainer with repo settings access can do that. Flagging it here so it's not lost; this PR does not address it.

## Verification

- `pytest tests/scripts/test_bump_api_dependency.py` → 10 passed
- `ruff check` / `ruff format` on changed `.py` → clean
- `pre-commit run` on the three changed files → all hooks passed
- Renovate dry-run confirms the disable now matches (see above)

## Files changed

- `renovate.json` — `matchPackageNames` → `matchDepNames` + explanatory `description`
- `scripts/bump_api_dependency.py` — body uses `current_pin` for the `from` field
- `tests/scripts/test_bump_api_dependency.py` — regression test for the `from` field

## Files intentionally not touched

`release.yml`, `.github/workflows/bump-api-dependency.yml`, `custom_components/kia_uvo/manifest.json`, the `hyundai_kia_connect_api` library.
