### PR TITLE
fix(scripts): qualify API issue/PR refs so semantic-release keeps API URLs

### DIFF
--- a/scripts/bump_api_dependency.py
+++ b/scripts/bump_api_dependency.py
@@ -65,7 +65,64 @@ def _tag_name(version_or_tag: str) -> str:
     )
 
 
-def _synthesize_body_from_commits(commits: list[dict[str, Any]]) -> str:
+def _normalize_issue_refs(body: str, owner: str, repo: str) -> str:
+    """Qualify issue/PR references so they survive a cross-repo paste.
+
+    API release notes are written in the API repo's context: ``#123`` and
+    ``[#123](url)`` point at API issues/PRs. ``jossef/action-semantic-release-info``
+    (used by kia_uvo's release workflow) regenerates unqualified ``[#NNN]``
+    references using the *release* repo's URL template, discarding the original
+    explicit URL — so ``[#1156](api-url)`` in the bump commit body becomes
+    ``[#1156](kia_uvo-url)`` in the kia_uvo release notes. Cross-repo-qualified
+    refs (``other-repo#NNN``) are left intact by the writer.
+
+    This helper rewrites every unqualified reference to ``owner/repo#NNN`` so the
+    writer treats it as cross-repo and does not rewrite the URL:
+
+      - ``[#NNN](url)``  -> ``[owner/repo#NNN](url)``  (keep URL, qualify text)
+      - ``[#NNN]``       -> ``[owner/repo#NNN]``
+      - plain ``#NNN``   -> ``owner/repo#NNN``
+
+    Left untouched: already-qualified refs (``owner/repo#NNN``,
+    ``other-repo#NNN``), and ``#`` anchors inside a github URL path
+    (``.../issues/123#comment``).
+    """
+    repo_ref = f"{owner}/{repo}"
+
+    # [#NNN](url) -> [owner/repo#NNN](url)
+    body = re.sub(
+        r"\[#(\d+)\]\(([^)]*)\)",
+        lambda m: f"[{repo_ref}#{m.group(1)}]({m.group(2)})",
+        body,
+    )
+
+    # [#NNN] without a following URL -> [owner/repo#NNN]
+    body = re.sub(
+        r"\[(#\d+)\](?!\()",
+        lambda m: f"[{repo_ref}{m.group(1)}]",
+        body,
+    )
+
+    # Plain #NNN, but not if it is already part of another repo's qualified ref
+    # (other-repo#NNN) or a URL anchor (.../issues/123#comment).
+    def _replace_plain(match: re.Match[str]) -> str:
+        start = match.start()
+        char_before = body[start - 1] if start > 0 else ""
+        # Part of a qualified ref like owner/repo#NNN or other-repo#NNN?
+        if re.match(r"[\w.-]", char_before):
+            return match.group(0)
+        # Anchor inside a github.com URL path (e.g. /issues/123#comment).
+        window = body[max(0, start - 40) : start]
+        if re.search(r"github\.com/.+/(issues|pull)/\d+$", window):
+            return match.group(0)
+        return f"{repo_ref}{match.group(0)}"
+
+    return re.sub(r"#(\d+)", _replace_plain, body)
+
+
+def _synthesize_body_from_commits(
+    commits: list[dict[str, Any]], owner: str = API_OWNER, repo: str = API_REPO
+) -> str:
     feat: list[str] = []
     fix: list[str] = []
     other: list[str] = []
@@ -97,13 +154,13 @@ def _synthesize_body_from_commits(commits: list[dict[str, Any]]) -> str:
         lines.append("BREAKING CHANGES")
     if feat:
         lines.append("### Features")
-        lines.extend(feat)
+        lines.extend(_normalize_issue_refs(line, owner, repo) for line in feat)
     if fix:
         lines.append("### Bug Fixes")
-        lines.extend(fix)
+        lines.extend(_normalize_issue_refs(line, owner, repo) for line in fix)
     if not feat and not fix and other:
         lines.append("### Other Changes")
-        lines.extend(other)
+        lines.extend(_normalize_issue_refs(line, owner, repo) for line in other)
     return "\n".join(lines)
 
 
@@ -135,8 +192,10 @@ def _extract_section(body: str, headings: list[str]) -> str:
     return "\n".join(collected)
 
 
-def _classify_single_release(body: str) -> tuple[str, dict[str, list[str]]]:
-    body = body or ""
+def _classify_single_release(
+    body: str, owner: str = API_OWNER, repo: str = API_REPO
+) -> tuple[str, dict[str, list[str]]]:
+    body = _normalize_issue_refs(body or "", owner, repo)
     sections: dict[str, list[str]] = {
         "breaking": [],
         "features": [],
@@ -210,7 +269,7 @@ def classify_release_notes(
                 body = _synthesize_body_from_commits(compare.get("commits", []))
             except urllib.error.HTTPError:
                 body = ""
-        rel_level, sections = _classify_single_release(body)
+        rel_level, sections = _classify_single_release(body, owner, repo)
         if rel_level != "chore":
             level = max(
                 level, rel_level, key=["chore", "fix", "feat", "breaking"].index

--- a/tests/scripts/test_bump_api_dependency.py
+++ b/tests/scripts/test_bump_api_dependency.py
@@ -7,6 +7,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
 from bump_api_dependency import (
+    _normalize_issue_refs,
     classify_release_notes,
     get_current_pin,
     main,
@@ -102,6 +103,66 @@ def test_classify_release_notes_empty_body_falls_back_to_ignored_commits(monkeyp
     assert "### Other Changes" in body
     assert "- 4.22.0: cleanup" in body
     assert "- 4.22.0: update readme" in body
+
+
+def test_normalize_issue_refs_qualifies_markdown_link_text():
+    # Real-world shape: API release notes use [#NNN](api-url) markdown links.
+    # semantic-release rewrites unqualified [#NNN] URLs to the release repo;
+    # qualifying the link text as owner/repo#NNN makes the writer leave it alone.
+    owner, repo = "Hyundai-Kia-Connect", "hyundai_kia_connect_api"
+    body = (
+        "closes [#1155](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1155) "
+        "and [#1153](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1153)"
+    )
+    normalized = _normalize_issue_refs(body, owner, repo)
+    assert (
+        "[Hyundai-Kia-Connect/hyundai_kia_connect_api#1155]"
+        "(https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1155)"
+        in normalized
+    )
+    assert (
+        "[Hyundai-Kia-Connect/hyundai_kia_connect_api#1153]"
+        "(https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1153)"
+        in normalized
+    )
+    assert "[#1155]" not in normalized
+    assert "[#1153]" not in normalized
+
+
+def test_normalize_issue_refs_leaves_cross_repo_refs_intact():
+    owner, repo = "Hyundai-Kia-Connect", "hyundai_kia_connect_api"
+    body = "[kia_uvo#1683](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1683)"
+    normalized = _normalize_issue_refs(body, owner, repo)
+    assert body in normalized  # cross-repo qualified ref untouched
+
+
+def test_normalize_issue_refs_qualifies_bare_refs():
+    owner, repo = "Hyundai-Kia-Connect", "hyundai_kia_connect_api"
+    body = "Fixes (#1156) and [#1155]. Also see Hyundai-Kia-Connect/hyundai_kia_connect_api#1153."
+    normalized = _normalize_issue_refs(body, owner, repo)
+    assert "Hyundai-Kia-Connect/hyundai_kia_connect_api#1156" in normalized
+    assert "[Hyundai-Kia-Connect/hyundai_kia_connect_api#1155]" in normalized
+    assert "(#1156)" not in normalized
+
+
+def test_normalize_issue_refs_leaves_url_anchors_intact():
+    owner, repo = "Hyundai-Kia-Connect", "hyundai_kia_connect_api"
+    body = "https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1683#issuecomment-4728645908"
+    normalized = _normalize_issue_refs(body, owner, repo)
+    assert body in normalized  # the #issuecomment anchor is not an issue ref
+
+
+def test_classify_release_notes_rewrites_api_issue_refs():
+    releases = [
+        {
+            "tag_name": "v4.22.1",
+            "body": "### Bug Fixes\n- replace rotation ([#1156](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1156)), closes #1155 #1153\n",
+        }
+    ]
+    _commit_type, body = classify_release_notes(releases, "4.22.0")
+    assert "Hyundai-Kia-Connect/hyundai_kia_connect_api#1155" in body
+    assert "Hyundai-Kia-Connect/hyundai_kia_connect_api#1153" in body
+    assert "[#1156]" not in body  # markdown link text qualified
 
 
 def test_update_manifest(tmp_path):


### PR DESCRIPTION
## Problem

The kia_uvo `v3.6.0` release notes link API issue/PR numbers to the **kia_uvo** repo instead of the API repo. Example from the release body:

```
feat(deps): bump hyundai_kia_connect_api 4.22.0 → 4.23.1 (#1772) ... closes [#1715](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1715) [#1212](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1212) [#1156](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1156) ...
```

Clicking `#1156` goes to `Hyundai-Kia-Connect/kia_uvo/issues/1156`, but it should go to `Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1156`.

## Root cause

Verified against the actual artifacts:

- The bump commit body (`50f6785`, produced by this workflow) contains `[#1156](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1156)` — the URL correctly points at the API repo.
- The `v3.6.0` release body contains `[#1156](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1156)` — the URL was rewritten to kia_uvo.

The release workflow (`release.yml`) uses `jossef/action-semantic-release-info@v3.0.0` (conventional-changelog-writer) to generate `notes`. The writer **regenerates unqualified `[#NNN]` references using the release repo's URL template**, discarding the original explicit URL. Cross-repo-qualified references (`other-repo#NNN`) are left intact — proven by `[kia_uvo#1683](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1683)`, which appears identically in the commit body and the release.

API release notes use `[#NNN](api-url)` markdown links (semantic-release format). When the bump script copies them into the kia_uvo commit body, the writer rewrites the URLs to kia_uvo.

## Fix

Add `_normalize_issue_refs()` in `scripts/bump_api_dependency.py` that rewrites every unqualified reference to `owner/repo#NNN` so the writer treats it as cross-repo and preserves the URL:

| input | output |
|---|---|
| `[#NNN](url)` | `[owner/repo#NNN](url)` (qualify link text, keep URL) |
| `[#NNN]` | `[owner/repo#NNN]` |
| plain `#NNN` | `owner/repo#NNN` |

Left untouched:
- already-qualified refs (`owner/repo#NNN`, `other-repo#NNN`)
- URL anchors (`.../issues/123#comment`)

Applied to both API release note bodies (in `_classify_single_release`) and synthesized compare-commits fallback (in `_synthesize_body_from_commits`).

## Verification

- `pytest tests/scripts/test_bump_api_dependency.py` → **15 passed**
- `ruff check` / `ruff format` → clean
- `pre-commit run` on changed files → all hooks passed
- **Verified against the real `v4.22.1`, `v4.23.0`, `v4.23.1` API release bodies**: after normalization, `0` unqualified `[#NNN]` remain, `0` bare `#NNN` remain, cross-repo `kia_uvo#1683` preserved (3 occurrences). All `[#NNN](api-url)` became `[Hyundai-Kia-Connect/hyundai_kia_connect_api#NNN](api-url)`.

## Files changed

- `scripts/bump_api_dependency.py` — new `_normalize_issue_refs()` helper, applied in `_classify_single_release()` and `_synthesize_body_from_commits()`
- `tests/scripts/test_bump_api_dependency.py` — 5 new tests covering markdown-link qualification, cross-repo preservation, bare refs, URL anchors, and end-to-end `classify_release_notes`

## Files intentionally not touched

`.github/workflows/bump-api-dependency.yml`, `renovate.json`, `custom_components/kia_uvo/manifest.json`.
