### PR TITLE
fix(sensor): show EV battery in device header for BEV/PHEV (#1749)

### DIFF
--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -7,6 +7,7 @@ from typing import Final
 from datetime import date
 
 from hyundai_kia_connect_api import Vehicle
+from hyundai_kia_connect_api.const import ENGINE_TYPES
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -72,7 +73,6 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
-        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     SensorEntityDescription(
         key="last_updated_at",
@@ -460,6 +460,16 @@ class HyundaiKiaConnectSensor(SensorEntity, HyundaiKiaConnectEntity):
         self._attr_device_class = description.device_class
         if description.entity_category:
             self._attr_entity_category = description.entity_category
+        # For electrified vehicles (BEV/PHEV) the traction battery is the
+        # device's primary battery. Drop the battery device_class from the
+        # 12 V auxiliary sensor so Home Assistant's device-page battery picker
+        # (which selects the first sensor with device_class=battery, ignoring
+        # entity_category) shows the EV battery instead of the 12 V level.
+        # HEV/ICE keep the 12 V as their battery. See issue #1749.
+        if description.key == "car_battery_percentage":
+            engine_type = getattr(vehicle, "engine_type", None)
+            if engine_type in (ENGINE_TYPES.EV, ENGINE_TYPES.PHEV):
+                self._attr_device_class = None
 
     @property
     def native_value(self):


### PR DESCRIPTION
Fixes #1749. Supersedes the ineffective part of #1760.

## Problem

PR #1760 marked `car_battery_percentage` as `EntityCategory.DIAGNOSTIC` so the device-page header would show the EV battery instead of the 12 V level for electrified vehicles. **That did not work.** A reporter (FunkyTob, follow-up at Hyundai-Kia-Connect/kia_uvo#1781) confirmed on a live install (full HA restart, HA 2026.7 latest): the header still shows the 12 V battery; only the icon/position changed.

## Root cause

HA's device-page header battery is chosen by `findBatteryEntity` in `home-assistant/frontend` (`src/data/entity/entity_registry.ts`):

```js
const batteryPriorities = ["sensor", "binary_sensor"];
export const findBatteryEntity = (states, entities) => {
  const batteryEntities = entities
    .filter(e => states[e.entity_id] &&
                  states[e.entity_id].attributes.device_class === "battery" &&
                  batteryPriorities.includes(computeDomain(e.entity_id)))
    .sort((a, b) => batteryPriorities.indexOf(domain(a)) - batteryPriorities.indexOf(domain(b)));
  return batteryEntities[0];
};
```

- Filters **only** on `device_class === "battery"` + domain priority (sensor > binary_sensor).
- **`entity_category` (DIAGNOSTIC/CONFIG) is not checked at all.**
- Ties (both `sensor` + `device_class=battery`) are broken by **display-name sort** (`ha-config-device-page.ts` sorts the device's entities alphabetically by `stateName`). "Car Battery Level" (and "Poziom baterii 12V" in pl) sorts before "EV Battery Level" ("Poziom baterii EV") → the 12 V sensor always wins the header for EVs.

So `EntityCategory.DIAGNOSTIC` moved the 12 V sensor to the device page's Diagnostic card (hence "the icon changed") but did not remove it from the header picker.

## Fix

1. **Revert the ineffective `EntityCategory.DIAGNOSTIC`** on `car_battery_percentage` (added in #1760). Restores pre-#1760 non-diagnostic behavior and removes the unrequested side effect of hiding the 12 V sensor from default dashboards / voice assistants / area & label targets for ICE and HEV users (issue #1749 was about the EV header, not about hiding the 12 V).
2. **Drop `device_class=battery` from `car_battery_percentage` for BEV and PHEV** (`engine_type in {EV, PHEV}`) in `HyundaiKiaConnectSensor.__init__`. With the 12 V sensor no longer `device_class=battery`, `findBatteryEntity` selects `ev_battery_percentage` for the header. ICE and HEV keep the 12 V as their battery (HEV's traction battery is small; the 12 V is the more meaningful level — Santa Fe HEV keeps 12 V, by design).

`engine_type` is reliably set for all released regions: `ApiImplType1.get_vehicles` derives it from `entry["type"]` (`GN`→ICE, `EV`→EV, `PHEV`/`PE`→PHEV, `HV`→HEV), inherited by EU Kia/Hyundai, AU, CA, IN, CN; `HyundaiBlueLinkApiUSA` and `HyundaiBlueLinkApiBR` set it directly.

## No-regression matrix

| Vehicle | engine_type | car_battery entity_category | car_battery device_class | Device-page header |
|---|---|---|---|---|
| ICE | ICE | None (revert) | battery | 12 V (unchanged) |
| HEV (e.g. Santa Fe) | HEV | None (revert) | battery | 12 V (unchanged) |
| PHEV | PHEV | None (revert) | None (new) | EV (fix) |
| BEV (e.g. Ioniq 5, Inster) | EV | None (revert) | None (new) | EV (fix) |

## Tradeoff

For BEV/PHEV, `car_battery_percentage` loses `device_class=battery`, so it no longer appears in the mobile-app battery list or the battery dashboard. This is consistent with the traction battery being the device's primary battery for electrified vehicles, and the 12 V remains available as a normal sensor (drain monitoring still works — entity exists with its value). For ICE/HEV the 12 V keeps `device_class=battery` (their main/only battery).

## Verification

- `ruff check` + `ruff format` + `py_compile` pass.
- Root cause verified against HA frontend source (`findBatteryEntity`, `ha-config-device-page.ts`) and confirmed on a live HA install (Santa Fe HEV: both `car_battery` and `ev_battery` have `device_class=battery`; header shows 12 V because "Poziom baterii 12V" sorts before "Poziom baterii EV").
- kia_uvo has no pytest suite; BEV/PHEV header behavior to be confirmed by the reporter (FunkyTob, Hyundai Inster BEV) after release.

## Files changed

- `custom_components/kia_uvo/sensor.py` — import `ENGINE_TYPES`; revert `EntityCategory.DIAGNOSTIC` on `car_battery_percentage`; conditional `device_class=None` for `engine_type in {EV, PHEV}` in `__init__`.