### PR TITLE
fix(sensor): always create 12V battery sensor entity (#1803)

### DIFF
--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -463,6 +463,15 @@ async def async_setup_entry(
                     vehicle.air_control_is_on is not None
                     or vehicle._air_temperature is not None
                 )
+            elif description.key == "car_battery_percentage":
+                # The 12V SoC is transient — None while the telematics unit
+                # is asleep, after a 12V reset, or when the status payload
+                # omits it. Don't gate creation on it: a None at setup (e.g.
+                # a version-update reload) means the entity isn't yielded and
+                # HA marks it "no longer provided", with no return until the
+                # next reload. Always create; None -> HA `unknown`, the real
+                # SoC arrives on the next poll. See #1803.
+                create = True
             else:
                 create = getattr(vehicle, description.key, None) is not None
             if create:


### PR DESCRIPTION
## Problem

`car_battery_percentage` was gated on `is not None` at `async_setup_entry`. If the car reported `None` at integration setup — 12V drained, dealer SW update, telematics unit asleep, 12V reset, or a transient coinciding with a version-update reload — the entity was not yielded and HA marked it **"no longer being provided by the integration"**. It never came back without another reload, since entities are only added at setup.

Reported in #1803 (USA Kia Carnival, 3.7.1 → 3.8.0). Not a 3.8.0 regression — the gate predates it. The 3.8.0 update merely reloads the integration, which is what surfaces the pre-existing fragility.

## Fix

Always create the `car_battery_percentage` sensor (don't gate on the current value). A `None` value becomes HA `unknown`; the real SoC arrives on the next poll. Same pattern as #1791 used for `_air_temperature`.

## Why unconditional (vs. #1791's presence-signal gate)

#1791 gates `_air_temperature` on the stable `air_control_is_on` signal because some vehicles genuinely have **no climate** (permanent `None` → creating a sensor would be wrong).

For 12V there is no "vehicle has no 12V" case — every vehicle has a 12V battery and the telematics unit monitors it. `car_battery_percentage` is one of the most universal fields:

- All API-lib test fixtures (Ioniq 5, EV6, Niro EV, EV9) report it
- Every region class (BR / USA Hyundai / AU / EU Kia / CCI EU / USA Kia / CN / Type1 base / CA) populates it in `_update_vehicle_properties`
- HEV vehicles report it (e.g. EU CCS2 Santa Fe: `Electronics.Battery.Level`)

`None` is therefore always transient (unit asleep / 12V reset) or a sentinel (255 → `normalize_battery_soc` → `None`), not "this vehicle has no 12V sensor." `unknown` is the HA-correct representation of that state (data unknown), not stale-masking.

## Audit 

1. HA principles ✅ — `None` → `unknown` (data unknown), no stale-masking, no `RestoreEntity` abuse, `UpdateFailed` still propagates → `unavailable`. No car wakeup (setup-time only).
2. Pattern conformance ✅ — mirrors #1791's `create = ...` branch in the same loop.
3. No bloat ✅ — comment trimmed to #1791 density.
4. Structural hooks ✅ — nothing removed.
5. Right layer ✅ — `async_setup_entry`, same as #1791.
6. Type safety N/A — no new helper/enum.
7. Surgical scope ✅ — 12V is universal; global always-create is correct (not engine_type-specific).
8. No dead code ✅ — one coherent story.

## Files changed

- `custom_components/kia_uvo/sensor.py` — added `elif description.key == "car_battery_percentage": create = True` branch in the `async_setup_entry` entity-creation gate.

Closes #1803.