### PR TITLE
feat: time entities for off-peak charging window (#1764)

### DIFF
--- a/custom_components/kia_uvo/__init__.py
+++ b/custom_components/kia_uvo/__init__.py
@@ -41,6 +41,7 @@ PLATFORMS: list[str] = [
     Platform.NUMBER,
     Platform.SWITCH,
     Platform.CLIMATE,
+    Platform.TIME,
 ]
 
 

--- a/custom_components/kia_uvo/const.py
+++ b/custom_components/kia_uvo/const.py
@@ -1,5 +1,7 @@
 """Constants for the Hyundai / Kia Connect integration."""
 
+from enum import StrEnum
+
 DOMAIN: str = "kia_uvo"
 
 CONF_BRAND: str = "brand"
@@ -44,3 +46,16 @@ DEFAULT_ENABLE_GEOLOCATION_ENTITY: bool = False
 DEFAULT_USE_EMAIL_WITH_GEOCODE_API: bool = False
 
 DYNAMIC_UNIT: str = "dynamic_unit"
+
+
+class OffPeakChargingMode(StrEnum):
+    """Off-peak charging schedule mode.
+
+    Maps to the (charging_enabled, off_peak_charge_only_enabled) pair the API
+    expects. Values are the strings exposed in services.yaml so the service
+    payload converts directly: ``OffPeakChargingMode(call.data["mode"])``.
+    """
+
+    OFF = "off"
+    TIME = "time"
+    TARGET = "target"

--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -446,6 +446,22 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
         options.off_peak_charge_only_enabled = enabled
         await self.async_schedule_charging_and_climate(vehicle_id, options)
 
+    async def async_set_off_peak_time(
+        self,
+        vehicle_id: str,
+        *,
+        start: dt.time | None = None,
+        end: dt.time | None = None,
+    ) -> None:
+        """Set the off-peak charging window start and/or end time."""
+        vehicle = self.vehicle_manager.vehicles[vehicle_id]
+        options = self._build_schedule_options_from_vehicle(vehicle)
+        if start is not None:
+            options.off_peak_start_time = start
+        if end is not None:
+            options.off_peak_end_time = end
+        await self.async_schedule_charging_and_climate(vehicle_id, options)
+
     async def async_set_departure_enabled(
         self, vehicle_id: str, departure_num: int, enabled: bool
     ):

--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -462,6 +462,40 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
             options.off_peak_end_time = end
         await self.async_schedule_charging_and_climate(vehicle_id, options)
 
+    async def async_set_off_peak_charging_mode(
+        self,
+        vehicle_id: str,
+        mode: str,
+        *,
+        start: dt.time | None = None,
+        end: dt.time | None = None,
+    ) -> None:
+        """Set the off-peak charging schedule mode and optionally the window.
+
+        ``mode`` maps to the (charging_enabled, off_peak_charge_only_enabled)
+        pair the API expects: ``off`` disables scheduled charging, ``time``
+        charges only during the off-peak window (time priority), ``target``
+        prefers off-peak tariffs but continues past the window to reach the
+        target SoC (target priority). Other schedule fields are preserved.
+        """
+        vehicle = self.vehicle_manager.vehicles[vehicle_id]
+        options = self._build_schedule_options_from_vehicle(vehicle)
+        if mode == "off":
+            options.charging_enabled = False
+        elif mode == "time":
+            options.charging_enabled = True
+            options.off_peak_charge_only_enabled = True
+        elif mode == "target":
+            options.charging_enabled = True
+            options.off_peak_charge_only_enabled = False
+        else:
+            raise ValueError(f"Invalid off-peak charging mode: {mode!r}")
+        if start is not None:
+            options.off_peak_start_time = start
+        if end is not None:
+            options.off_peak_end_time = end
+        await self.async_schedule_charging_and_climate(vehicle_id, options)
+
     async def async_set_departure_enabled(
         self, vehicle_id: str, departure_num: int, enabled: bool
     ):

--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -52,6 +52,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_USE_EMAIL_WITH_GEOCODE_API,
     DOMAIN,
+    OffPeakChargingMode,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -446,50 +447,35 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
         options.off_peak_charge_only_enabled = enabled
         await self.async_schedule_charging_and_climate(vehicle_id, options)
 
-    async def async_set_off_peak_time(
+    async def async_set_off_peak_charging(
         self,
         vehicle_id: str,
         *,
+        mode: OffPeakChargingMode | None = None,
         start: dt.time | None = None,
         end: dt.time | None = None,
     ) -> None:
-        """Set the off-peak charging window start and/or end time."""
-        vehicle = self.vehicle_manager.vehicles[vehicle_id]
-        options = self._build_schedule_options_from_vehicle(vehicle)
-        if start is not None:
-            options.off_peak_start_time = start
-        if end is not None:
-            options.off_peak_end_time = end
-        await self.async_schedule_charging_and_climate(vehicle_id, options)
-
-    async def async_set_off_peak_charging_mode(
-        self,
-        vehicle_id: str,
-        mode: str,
-        *,
-        start: dt.time | None = None,
-        end: dt.time | None = None,
-    ) -> None:
-        """Set the off-peak charging schedule mode and optionally the window.
+        """Set the off-peak charging schedule mode and/or window.
 
         ``mode`` maps to the (charging_enabled, off_peak_charge_only_enabled)
-        pair the API expects: ``off`` disables scheduled charging, ``time``
-        charges only during the off-peak window (time priority), ``target``
+        pair the API expects: ``OFF`` disables scheduled charging, ``TIME``
+        charges only during the off-peak window (time priority), ``TARGET``
         prefers off-peak tariffs but continues past the window to reach the
-        target SoC (target priority). Other schedule fields are preserved.
+        target SoC (target priority). ``mode=None`` preserves the current mode
+        and only adjusts the window — used by the time entities. Other
+        schedule fields (departures) are preserved.
         """
         vehicle = self.vehicle_manager.vehicles[vehicle_id]
         options = self._build_schedule_options_from_vehicle(vehicle)
-        if mode == "off":
-            options.charging_enabled = False
-        elif mode == "time":
-            options.charging_enabled = True
-            options.off_peak_charge_only_enabled = True
-        elif mode == "target":
-            options.charging_enabled = True
-            options.off_peak_charge_only_enabled = False
-        else:
-            raise ValueError(f"Invalid off-peak charging mode: {mode!r}")
+        if mode is not None:
+            if mode is OffPeakChargingMode.OFF:
+                options.charging_enabled = False
+            elif mode is OffPeakChargingMode.TIME:
+                options.charging_enabled = True
+                options.off_peak_charge_only_enabled = True
+            elif mode is OffPeakChargingMode.TARGET:
+                options.charging_enabled = True
+                options.off_peak_charge_only_enabled = False
         if start is not None:
             options.off_peak_start_time = start
         if end is not None:

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -1,20 +1,13 @@
 {
   "domain": "kia_uvo",
   "name": "Kia Uvo / Hyundai Bluelink",
-  "codeowners": [
-    "@fuatakgun"
-  ],
+  "codeowners": ["@fuatakgun"],
   "config_flow": true,
   "documentation": "https://github.com/Hyundai-Kia-Connect/kia_uvo",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Hyundai-Kia-Connect/kia_uvo/issues",
-  "loggers": [
-    "kia_uvo",
-    "hyundai_kia_connect_api"
-  ],
-  "requirements": [
-    "hyundai_kia_connect_api==4.26.0"
-  ],
+  "loggers": ["kia_uvo", "hyundai_kia_connect_api"],
+  "requirements": ["hyundai_kia_connect_api==4.26.0"],
   "version": "3.8.1"
 }

--- a/custom_components/kia_uvo/services.py
+++ b/custom_components/kia_uvo/services.py
@@ -14,7 +14,7 @@ from hyundai_kia_connect_api import (
     WindowRequestOptions,
 )
 
-from .const import DOMAIN
+from .const import DOMAIN, OffPeakChargingMode
 from .coordinator import HyundaiKiaConnectDataUpdateCoordinator
 
 SERVICE_UPDATE = "update"
@@ -284,9 +284,9 @@ def async_setup_services(hass: HomeAssistant) -> bool:
             ).time()
         if off_peak_end_time is not None:
             off_peak_end_time = datetime.strptime(off_peak_end_time, "%H:%M:%S").time()
-        await coordinator.async_set_off_peak_charging_mode(
+        await coordinator.async_set_off_peak_charging(
             vehicle_id,
-            mode,
+            mode=OffPeakChargingMode(mode) if mode is not None else None,
             start=off_peak_start_time,
             end=off_peak_end_time,
         )

--- a/custom_components/kia_uvo/services.py
+++ b/custom_components/kia_uvo/services.py
@@ -36,6 +36,7 @@ SERVICE_START_VALET_MODE = "start_valet_mode"
 SERVICE_STOP_VALET_MODE = "stop_valet_mode"
 SERVICE_SET_WINDOWS = "set_windows"
 SERVICE_SET_NAVIGATION = "set_navigation"
+SERVICE_SET_OFF_PEAK_CHARGING = "set_off_peak_charging"
 
 SUPPORTED_SERVICES = (
     SERVICE_UPDATE,
@@ -57,6 +58,7 @@ SUPPORTED_SERVICES = (
     SERVICE_STOP_VALET_MODE,
     SERVICE_SET_WINDOWS,
     SERVICE_SET_NAVIGATION,
+    SERVICE_SET_OFF_PEAK_CHARGING,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -270,6 +272,25 @@ def async_setup_services(hass: HomeAssistant) -> bool:
             vehicle_id, schedule_options
         )
 
+    async def async_handle_set_off_peak_charging(call):
+        coordinator = _get_coordinator_from_device(hass, call)
+        vehicle_id = _get_vehicle_id_from_device(hass, call)
+        mode = call.data.get("mode")
+        off_peak_start_time = call.data.get("off_peak_start_time")
+        off_peak_end_time = call.data.get("off_peak_end_time")
+        if off_peak_start_time is not None:
+            off_peak_start_time = datetime.strptime(
+                off_peak_start_time, "%H:%M:%S"
+            ).time()
+        if off_peak_end_time is not None:
+            off_peak_end_time = datetime.strptime(off_peak_end_time, "%H:%M:%S").time()
+        await coordinator.async_set_off_peak_charging_mode(
+            vehicle_id,
+            mode,
+            start=off_peak_start_time,
+            end=off_peak_end_time,
+        )
+
     async def async_handle_start_hazard_lights(call):
         coordinator = _get_coordinator_from_device(hass, call)
         vehicle_id = _get_vehicle_id_from_device(hass, call)
@@ -329,6 +350,7 @@ def async_setup_services(hass: HomeAssistant) -> bool:
         SERVICE_STOP_VALET_MODE: async_handle_stop_valet_mode,
         SERVICE_SET_WINDOWS: async_handle_set_windows,
         SERVICE_SET_NAVIGATION: async_handle_set_navigation,
+        SERVICE_SET_OFF_PEAK_CHARGING: async_handle_set_off_peak_charging,
     }
 
     for service in SUPPORTED_SERVICES:

--- a/custom_components/kia_uvo/services.yaml
+++ b/custom_components/kia_uvo/services.yaml
@@ -499,3 +499,35 @@ set_navigation:
       required: false
       selector:
         text:
+set_off_peak_charging:
+  description: >-
+    Set the off-peak charging schedule mode and optionally the window. "Off"
+    disables scheduled charging. "Time priority" charges only during the
+    off-peak window (may not reach the target SoC). "Target priority" prefers
+    off-peak tariffs but continues past the window to reach the target SoC.
+    Leave the start/end times blank to keep the current window.
+  fields:
+    device_id:
+      required: false
+      selector:
+        device:
+          integration: kia_uvo
+    mode:
+      required: true
+      selector:
+        select:
+          options:
+            - label: "Off"
+              value: "off"
+            - label: "Time priority (charge only off-peak)"
+              value: "time"
+            - label: "Target priority (off-peak tariffs, charge to target)"
+              value: "target"
+    off_peak_start_time:
+      required: false
+      selector:
+        time:
+    off_peak_end_time:
+      required: false
+      selector:
+        time:

--- a/custom_components/kia_uvo/strings.json
+++ b/custom_components/kia_uvo/strings.json
@@ -587,6 +587,14 @@
       "location": {
         "name": "Location"
       }
+    },
+    "time": {
+      "ev_off_peak_start_time": {
+        "name": "Off-peak charge start time"
+      },
+      "ev_off_peak_end_time": {
+        "name": "Off-peak charge end time"
+      }
     }
   }
 }

--- a/custom_components/kia_uvo/time.py
+++ b/custom_components/kia_uvo/time.py
@@ -1,0 +1,99 @@
+"""Time entities for Hyundai / Kia Connect integration."""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+import logging
+from typing import Final
+
+from homeassistant.components.time import TimeEntity, TimeEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from hyundai_kia_connect_api import Vehicle
+
+from .const import DOMAIN
+from .coordinator import HyundaiKiaConnectDataUpdateCoordinator
+from .entity import HyundaiKiaConnectEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class HyundaiKiaTimeDescription(TimeEntityDescription):
+    value_fn: Callable[[Vehicle], dt.time | None]
+    exists_fn: Callable[[Vehicle], bool]
+    set_fn: Callable[
+        [HyundaiKiaConnectDataUpdateCoordinator, str, dt.time], Awaitable[None]
+    ]
+
+
+TIME_DESCRIPTIONS: Final[tuple[HyundaiKiaTimeDescription, ...]] = (
+    HyundaiKiaTimeDescription(
+        key="ev_off_peak_start_time",
+        translation_key="ev_off_peak_start_time",
+        icon="mdi:clock-time-ten",
+        value_fn=lambda vehicle: vehicle.ev_off_peak_start_time,
+        exists_fn=lambda vehicle: vehicle.ev_off_peak_start_time is not None,
+        set_fn=lambda coordinator, vid, value: coordinator.async_set_off_peak_time(
+            vid, start=value
+        ),
+    ),
+    HyundaiKiaTimeDescription(
+        key="ev_off_peak_end_time",
+        translation_key="ev_off_peak_end_time",
+        icon="mdi:clock-time-two",
+        value_fn=lambda vehicle: vehicle.ev_off_peak_end_time,
+        exists_fn=lambda vehicle: vehicle.ev_off_peak_end_time is not None,
+        set_fn=lambda coordinator, vid, value: coordinator.async_set_off_peak_time(
+            vid, end=value
+        ),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator = hass.data[DOMAIN][config_entry.unique_id]
+    entities = []
+    for vehicle_id in coordinator.vehicle_manager.vehicles.keys():
+        vehicle: Vehicle = coordinator.vehicle_manager.vehicles[vehicle_id]
+        for description in TIME_DESCRIPTIONS:
+            if description.exists_fn(vehicle):
+                entities.append(
+                    HyundaiKiaConnectTimeEntity(coordinator, description, vehicle)
+                )
+
+    async_add_entities(entities)
+
+
+PARALLEL_UPDATES = 1
+
+
+class HyundaiKiaConnectTimeEntity(TimeEntity, HyundaiKiaConnectEntity):
+    entity_description: HyundaiKiaTimeDescription
+
+    def __init__(
+        self,
+        coordinator: HyundaiKiaConnectDataUpdateCoordinator,
+        description: HyundaiKiaTimeDescription,
+        vehicle: Vehicle,
+    ) -> None:
+        HyundaiKiaConnectEntity.__init__(self, coordinator, vehicle)
+        self.entity_description = description
+        self._attr_unique_id = f"{DOMAIN}_{vehicle.id}_{description.key}"
+        self._attr_icon = description.icon
+
+    @property
+    def native_value(self) -> dt.time | None:
+        return self.entity_description.value_fn(self.vehicle)
+
+    async def async_set_value(self, value: dt.time) -> None:
+        await self.entity_description.set_fn(self.coordinator, self.vehicle.id, value)
+        self.async_write_ha_state()

--- a/custom_components/kia_uvo/time.py
+++ b/custom_components/kia_uvo/time.py
@@ -3,16 +3,15 @@
 from __future__ import annotations
 
 import datetime as dt
+import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-import logging
 from typing import Final
 
 from homeassistant.components.time import TimeEntity, TimeEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-
 from hyundai_kia_connect_api import Vehicle
 
 from .const import DOMAIN
@@ -62,7 +61,7 @@ async def async_setup_entry(
 ) -> None:
     coordinator = hass.data[DOMAIN][config_entry.unique_id]
     entities = []
-    for vehicle_id in coordinator.vehicle_manager.vehicles.keys():
+    for vehicle_id in coordinator.vehicle_manager.vehicles:
         vehicle: Vehicle = coordinator.vehicle_manager.vehicles[vehicle_id]
         for description in TIME_DESCRIPTIONS:
             if description.exists_fn(vehicle):

--- a/custom_components/kia_uvo/time.py
+++ b/custom_components/kia_uvo/time.py
@@ -38,7 +38,7 @@ TIME_DESCRIPTIONS: Final[tuple[HyundaiKiaTimeDescription, ...]] = (
         icon="mdi:clock-time-ten",
         value_fn=lambda vehicle: vehicle.ev_off_peak_start_time,
         exists_fn=lambda vehicle: vehicle.ev_off_peak_start_time is not None,
-        set_fn=lambda coordinator, vid, value: coordinator.async_set_off_peak_time(
+        set_fn=lambda coordinator, vid, value: coordinator.async_set_off_peak_charging(
             vid, start=value
         ),
     ),
@@ -48,7 +48,7 @@ TIME_DESCRIPTIONS: Final[tuple[HyundaiKiaTimeDescription, ...]] = (
         icon="mdi:clock-time-two",
         value_fn=lambda vehicle: vehicle.ev_off_peak_end_time,
         exists_fn=lambda vehicle: vehicle.ev_off_peak_end_time is not None,
-        set_fn=lambda coordinator, vid, value: coordinator.async_set_off_peak_time(
+        set_fn=lambda coordinator, vid, value: coordinator.async_set_off_peak_charging(
             vid, end=value
         ),
     ),

--- a/custom_components/kia_uvo/translations/en.json
+++ b/custom_components/kia_uvo/translations/en.json
@@ -893,6 +893,14 @@
       "location": {
         "name": "Location"
       }
+    },
+    "time": {
+      "ev_off_peak_start_time": {
+        "name": "Off-peak charge start time"
+      },
+      "ev_off_peak_end_time": {
+        "name": "Off-peak charge end time"
+      }
     }
   }
 }

--- a/custom_components/kia_uvo/translations/pl.json
+++ b/custom_components/kia_uvo/translations/pl.json
@@ -725,6 +725,9 @@
       },
       "climate": {
         "name": "Klimatyzacja"
+      },
+      "ev_off_peak_charge_only_enabled": {
+        "name": "Ładowanie tylko poza szczytem"
       }
     },
     "climate": {
@@ -746,6 +749,14 @@
     "device_tracker": {
       "location": {
         "name": "Lokalizacja"
+      }
+    },
+    "time": {
+      "ev_off_peak_start_time": {
+        "name": "Czas początku ładowania poza szczytem"
+      },
+      "ev_off_peak_end_time": {
+        "name": "Czas końca ładowania poza szczytem"
       }
     }
   }


### PR DESCRIPTION
## Depends on `hyundai_kia_connect_api` #1251 — ✅ merged & released (4.26.0)

#1251 was merged and released as `hyundai_kia_connect_api==4.26.0`; kia_uvo `master` is already pinned to 4.26.0 (#1826), so this PR is now unblocked and the `ev_off_peak_*` attributes it reads are populated by the library.

## Summary

Part of #1764 — exposes and controls the off-peak charging schedule from Home Assistant.

- **`time.py`** — new `TimeEntity` platform with `ev_off_peak_start_time` and `ev_off_peak_end_time`, following the existing description pattern. `exists_fn` gates on `is not None`, consistent with `switch.py`/`sensor.py`.
- **`coordinator.py`** — `async_set_off_peak_charging(*, mode=None, start, end)` building on `_build_schedule_options_from_vehicle` + `async_schedule_charging_and_climate`. `mode=None` preserves the current mode (time-entity path); the mode maps to the `(charging_enabled, off_peak_charge_only_enabled)` pair the API expects.
- **`set_off_peak_charging` service** — convenience preset: a single `mode` selector (Off / Time priority / Target priority) + optional start/end window, with a `description` (hassfest allows `description` on services, unlike on entities) that carries the time-vs-target priority explanation. Non-breaking additive service; the existing `schedule_charging_and_climate` low-level service and the switch/time entities are unchanged.
- **`strings.json` + `en.json` + `pl.json`** — names for the two time entities. Other language files fall back to `strings.json` (existing sparse convention; `pl.json` time-entity names are English placeholders to be translated). Entity entries use only `name` (hassfest rejects `description` on entities).
- **`__init__.py`** — register `Platform.TIME`.

The library side (`schedule_charging_and_climate`, including the EV5-appMode flat-endpoint dispatch for ccNC EVs) lives in `hyundai_kia_connect_api` #1251 — this PR only consumes it.

## Note on the existing `schedule_charging_and_climate` service

The pre-existing `schedule_charging_and_climate` service is a **full-reset** service: it builds the request from the call data only (not from the current vehicle state), and omitted fields fall back to defaults (e.g. `charging_enabled` defaults to `false`). **Callers must specify every field they want kept** — omitting `charging_enabled` disables scheduled charging, and omitting the departure fields disables the departure presets.

Now that #1251 makes the service actually apply for ccNC/EV5 vehicles (previously the combined `/ccs2/reservation/chargehvac` was a no-op for them), this full-reset behaviour is active for those vehicles too. The new **`set_off_peak_charging` preset service** and the **time entities** added here are the **partial-update** path: they preserve the current schedule via `_build_schedule_options_from_vehicle` and override only the field(s) being changed, so they are safe to call without resetting the rest of the schedule. Prefer them for partial changes; use the low-level service only when you intend to set the whole schedule at once.

## Pre-merge checks (self-audit)

1. **HA principles**: `exists_fn` None-gates, consistent with `switch.py`/`sensor.py`. No wake on a cheap path; writes go through the coordinator.
2. **Pattern conformance**: time entity + coordinator helpers + service mirror existing patterns (`open_charge_port` description, `schedule_charging_and_climate` handler). Translations follow the existing sparse convention.
3. **No bloat**: focused additions; no English duplicated across language files (fallback); the preset service reuses existing coordinator plumbing.
4. **Structural hooks**: reuses `_build_schedule_options_from_vehicle` + `async_schedule_charging_and_climate`; the low-level `schedule_charging_and_climate` service and the switch are kept.
5. **Right layer**: entities in `time.py`, write orchestration in `coordinator.py`, service wiring in `services.py`.
6. **Type safety**: full hints; `mode` validated in the coordinator (`ValueError` on unknown).
7. **Surgical scope**: additive (new platform + service + helpers); no existing service/entity changed — non-breaking.
8. **No dead code**.

## Test plan

- [x] `ruff check` + `ruff format` — clean
- [x] `python -m py_compile` on `time.py`/`coordinator.py`/`services.py`/`const.py`/`__init__.py` — OK
- [x] YAML + JSON validity — OK
- [x] `pre-commit run` (ruff/codespell/pyupgrade/yamllint/prettier) — pass
- [x] `validate-hassfest` — pass (no `description` on entities; service `description` allowed)
- [ ] Functional: pending live test against 4.26.0