### PR TITLE
chore: adopt ruff 0.16 default rules (selective ignore + mechanical fixes)

### DIFF
--- a/custom_components/kia_uvo/binary_sensor.py
+++ b/custom_components/kia_uvo/binary_sensor.py
@@ -566,7 +566,7 @@ async def async_setup_entry(
     """Set up binary_sensor platform."""
     coordinator = hass.data[DOMAIN][config_entry.unique_id]
     entities: list[HyundaiKiaConnectBinarySensor] = []
-    for vehicle_id in coordinator.vehicle_manager.vehicles.keys():
+    for vehicle_id in coordinator.vehicle_manager.vehicles:
         vehicle: Vehicle = coordinator.vehicle_manager.vehicles[vehicle_id]
         for description in SENSOR_DESCRIPTIONS:
             if getattr(vehicle, description.key, None) is not None:

--- a/custom_components/kia_uvo/button.py
+++ b/custom_components/kia_uvo/button.py
@@ -102,7 +102,7 @@ async def async_setup_entry(
 ) -> None:
     coordinator = hass.data[DOMAIN][config_entry.unique_id]
     entities = []
-    for vehicle_id in coordinator.vehicle_manager.vehicles.keys():
+    for vehicle_id in coordinator.vehicle_manager.vehicles:
         vehicle: Vehicle = coordinator.vehicle_manager.vehicles[vehicle_id]
         for description in BUTTON_DESCRIPTIONS:
             if description.exists_fn(vehicle):

--- a/custom_components/kia_uvo/climate.py
+++ b/custom_components/kia_uvo/climate.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from time import sleep
+from typing import ClassVar
 
 from homeassistant.components.climate import ClimateEntity, ClimateEntityDescription
 from homeassistant.components.climate.const import (
@@ -55,14 +56,16 @@ class HyundaiKiaCarClimateControlSwitch(HyundaiKiaConnectEntity, ClimateEntity):
 
     # TODO: if possible in Climate, add possibility to set those
     # as well. Are there maybe additional properties?
-    heat_status_int_to_str: dict[int | None, str | None] = {
+    heat_status_int_to_str: ClassVar[dict[int | None, str | None]] = {
         None: None,
         0: "Off",
         1: "Steering Wheel and Rear Window",
         2: "Rear Window",
         3: "Steering Wheel",
     }
-    heat_status_str_to_int = {v: k for [k, v] in heat_status_int_to_str.items()}
+    heat_status_str_to_int: ClassVar[dict[str | None, int | None]] = {
+        v: k for [k, v] in heat_status_int_to_str.items()
+    }
 
     def get_internal_heat_int_for_climate_request(self):
         if (

--- a/custom_components/kia_uvo/cover.py
+++ b/custom_components/kia_uvo/cover.py
@@ -65,7 +65,7 @@ async def async_setup_entry(
 ) -> None:
     coordinator = hass.data[DOMAIN][config_entry.unique_id]
     entities = []
-    for vehicle_id in coordinator.vehicle_manager.vehicles.keys():
+    for vehicle_id in coordinator.vehicle_manager.vehicles:
         vehicle: Vehicle = coordinator.vehicle_manager.vehicles[vehicle_id]
         if not vehicle.supports_window_control:
             continue

--- a/custom_components/kia_uvo/device_tracker.py
+++ b/custom_components/kia_uvo/device_tracker.py
@@ -25,7 +25,7 @@ async def async_setup_entry(
 ) -> None:
     coordinator = hass.data[DOMAIN][config_entry.unique_id]
     entities = []
-    for vehicle_id in coordinator.vehicle_manager.vehicles.keys():
+    for vehicle_id in coordinator.vehicle_manager.vehicles:
         vehicle: Vehicle = coordinator.vehicle_manager.vehicles[vehicle_id]
         if vehicle.location is not None:
             entities.append(HyundaiKiaConnectTracker(coordinator, vehicle))

--- a/custom_components/kia_uvo/diagnostics.py
+++ b/custom_components/kia_uvo/diagnostics.py
@@ -93,7 +93,7 @@ def _vehicles_payload(
     for vehicle_id, vehicle in vm.vehicles.items():
         try:
             vehicles.append({"vehicle_id": vehicle_id, "data": asdict(vehicle)})
-        except Exception as exc:  # noqa: BLE001 — diagnostics must be resilient
+        except Exception as exc:
             vehicles.append(
                 {"vehicle_id": vehicle_id, "error": f"{type(exc).__name__}: {exc}"}
             )

--- a/custom_components/kia_uvo/lock.py
+++ b/custom_components/kia_uvo/lock.py
@@ -24,7 +24,7 @@ async def async_setup_entry(
 ) -> None:
     coordinator = hass.data[DOMAIN][config_entry.unique_id]
     entities = []
-    for vehicle_id in coordinator.vehicle_manager.vehicles.keys():
+    for vehicle_id in coordinator.vehicle_manager.vehicles:
         vehicle: Vehicle = coordinator.vehicle_manager.vehicles[vehicle_id]
         entities.append(HyundaiKiaConnectLock(coordinator, vehicle))
 

--- a/custom_components/kia_uvo/number.py
+++ b/custom_components/kia_uvo/number.py
@@ -65,7 +65,7 @@ async def async_setup_entry(
 ) -> None:
     coordinator = hass.data[DOMAIN][config_entry.unique_id]
     entities = []
-    for vehicle_id in coordinator.vehicle_manager.vehicles.keys():
+    for vehicle_id in coordinator.vehicle_manager.vehicles:
         vehicle: Vehicle = coordinator.vehicle_manager.vehicles[vehicle_id]
         for description in NUMBER_DESCRIPTIONS:
             if getattr(vehicle, description.key, None) is not None:

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -447,7 +447,7 @@ async def async_setup_entry(
     """Set up sensor platform."""
     coordinator = hass.data[DOMAIN][config_entry.unique_id]
     entities = []
-    for vehicle_id in coordinator.vehicle_manager.vehicles.keys():
+    for vehicle_id in coordinator.vehicle_manager.vehicles:
         vehicle: Vehicle = coordinator.vehicle_manager.vehicles[vehicle_id]
         for description in SENSOR_DESCRIPTIONS:
             if description.key == "_air_temperature":

--- a/custom_components/kia_uvo/services.py
+++ b/custom_components/kia_uvo/services.py
@@ -348,7 +348,7 @@ def _get_vehicle_id_from_device(hass: HomeAssistant, call: ServiceCall) -> str:
         coordinator = hass.data[DOMAIN][coordinators[0]]
         vehicles = coordinator.vehicle_manager.vehicles
         if len(vehicles) == 1:
-            return list(vehicles.keys())[0]
+            return next(iter(vehicles.keys()))
 
     device_entry = device_registry.async_get(hass).async_get(call.data[ATTR_DEVICE_ID])
     for entry in device_entry.identifiers:

--- a/custom_components/kia_uvo/switch.py
+++ b/custom_components/kia_uvo/switch.py
@@ -191,7 +191,7 @@ async def async_setup_entry(
 ) -> None:
     coordinator = hass.data[DOMAIN][config_entry.unique_id]
     entities = []
-    for vehicle_id in coordinator.vehicle_manager.vehicles.keys():
+    for vehicle_id in coordinator.vehicle_manager.vehicles:
         vehicle: Vehicle = coordinator.vehicle_manager.vehicles[vehicle_id]
         for description in SWITCH_DESCRIPTIONS:
             if description.exists_fn(vehicle):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.ruff]
+target-version = "py313"
+
+[tool.ruff.lint]
+ignore = [
+  "BLE001",  # except Exception — resilience pattern (ConfigEntryNotReady catch-all, force_refresh catch-all) — permanent
+  # DTZ* — naive datetime; deferred to separate tz-aware migration PR (all-or-nothing)
+  "DTZ001",
+  "DTZ004",
+  "DTZ005",
+  "DTZ006",
+  "DTZ007",
+  "DTZ011",
+  "DTZ901",
+]

--- a/scripts/bump_api_dependency.py
+++ b/scripts/bump_api_dependency.py
@@ -134,7 +134,7 @@ def _synthesize_body_from_commits(
         lower = message.lower()
         if "breaking change" in lower or "breaking changes" in lower:
             breaking = True
-        if lower.startswith("feat") or lower.startswith("fix"):
+        if lower.startswith(("feat", "fix")):
             clean = re.sub(
                 r"^(feat|fix)(?:\([^)]+\))?!?:\s*", "", message, flags=re.IGNORECASE
             )
@@ -273,9 +273,9 @@ def classify_release_notes(
             level = max(
                 level, rel_level, key=["chore", "fix", "feat", "breaking"].index
             )
-        for key in aggregate:
+        for key, value in aggregate.items():
             for item in sections.get(key, []):
-                aggregate[key].append(f"- {tag}: {item}")
+                value.append(f"- {tag}: {item}")
 
     last = releases[-1]["tag_name"].lstrip("vV")
     included = ", ".join(r["tag_name"].lstrip("vV") for r in releases)


### PR DESCRIPTION
## Summary

Upstream #1812 (`chore: pre-commit autoupdate`) bumped ruff to v0.16.0. kia_uvo had **no ruff config** (no `pyproject.toml`, `setup.cfg`, or `.ruff.toml`), so ruff ran with pure defaults. The 0.16 default ruleset is broader than 0.15.22 — every PR rebased onto master inherited a `pre-commit.ci` FAIL from pre-existing code.

This PR adopts the new default ruleset **selectively** (same approach as `hyundai_kia_connect_api` #1256), rather than pinning ruff to 0.15 — pinning only hides the problem and the next autoupdate restores it.

## Changes

### `pyproject.toml` (new — kia_uvo had none)

```toml
[tool.ruff]
target-version = "py313"

[tool.ruff.lint]
ignore = [
  "BLE001",  # except Exception — resilience pattern — permanent
  # DTZ* — naive datetime; deferred to separate tz-aware migration PR
  "DTZ001", "DTZ004", "DTZ005", "DTZ006", "DTZ007", "DTZ011", "DTZ901",
]
```

- **`BLE001`** (permanent): `except Exception` resilience pattern — `__init__.py` wraps into `ConfigEntryNotReady`, `coordinator.py` guards `force_refresh`. Catch-all is intentional HA convention here.
- **`DTZ*`** (deferred): naive datetime, 7 sites (`services.py` `strptime(time, "%H:%M:%S").time()` — time-only parse from service-call strings; `sensor.py` `date.today()` for today's date in state). All-or-nothing tz-aware migration — deferred to a separate PR with a timestamp audit, same call as API #1256.
- **`target-version = "py313"`**: `hacs.json` minimum is HA 2025.1 (Python 3.13). py314 would risk suggesting py3.14-only syntax that breaks py3.13 installs.

### Mechanical fixes (baseline: 20 errors across all tracked .py)

| Rule | Count | File(s) | Fix |
|---|---|---|---|
| `SIM118` | 8 | 8 platform files | drop `.keys()` in `for vehicle_id in vehicles.keys()` setup loops (no dict mutation inside loop) |
| `RUF012` | 2 | `climate.py` | `heat_status_int_to_str` / `heat_status_str_to_int` lookup tables → `ClassVar[dict[...]]` (class-level constants, never mutated — distinct from API #1256 `temperature_range`→`tuple` which instances reassign) |
| `RUF015` | 1 | `services.py` | `list(vehicles.keys())[0]` → `next(iter(vehicles.keys()))` (after `len(vehicles) == 1` guard) |
| `RUF100` | 1 | `diagnostics.py` | drop redundant `# noqa: BLE001` (now ignored globally in `pyproject.toml`) |
| `PIE810` | 1 | `scripts/bump_api_dependency.py` | `lower.startswith("feat") or lower.startswith("fix")` → `lower.startswith(("feat", "fix"))` |
| `PLC0206` | 1 | `scripts/bump_api_dependency.py` | `for key in aggregate: aggregate[key].append(...)` → `for key, value in aggregate.items(): value.append(...)` (only list values mutated, no dict key add/del in loop) |

`DTZ007` (3) + `DTZ011` (2) + `BLE001` (2) = 7 ignored via config (counted in baseline, not fixed).

No behavioral changes — ruff only.

## Why `ClassVar` and not `tuple` for RUF012

In API #1256, `temperature_range` became a `tuple` because instances reassign `self.temperature_range = range(...)`. Here, `heat_status_int_to_str` / `heat_status_str_to_int` are never reassigned or mutated (verified via grep — only definitions + reads via `.items()` and lookup). `ClassVar[dict[...]]` is the semantically correct annotation: an immutable-in-intent class-level lookup table.

## Scope note

Inventory covers **all tracked `.py`** (26 files: 17 `custom_components/kia_uvo/` + 2 `scripts/` + 7 `tests/`), not just the package — pre-commit.ci runs ruff on the whole repo. `tests/` and `scripts/__init__.py` were already clean.

## Follow-up

- DTZ* tz-aware migration PR (7 sites) — separate, after this merges. Same deferral as API #1256.

## Checklist

- [x] `ruff check` (v0.16.0) passes on all tracked `.py`
- [x] `ruff format --check` passes
- [x] `pre-commit run --files` passes (all hooks)
- [x] No behavioral changes (ruff-only chore)