### PR TITLE
feat(services): add start_climate heating option 1 (Steering + Side + Back Defroster, EU)

### DIFF
--- a/custom_components/kia_uvo/services.yaml
+++ b/custom_components/kia_uvo/services.yaml
@@ -62,6 +62,8 @@ start_climate:
               value: "0"
             - label: "Steering Wheel(not EU), Side and Back Defroster"
               value: "4"
+            - label: "Steering Wheel (EU some models), Side and Back Defroster"
+              value: "1"
             - label: "Rear Window Only"
               value: "2"
             - label: "Steering Wheel Only(None EU only)"


### PR DESCRIPTION
## Summary

The `start_climate` service `heating` selector offered values `0`/`2`/`3`/`4` but omitted `1`, which on some EU models (e.g. Hyundai Kona EV) is the EU equivalent of `4` — steering wheel + side and back defroster. Setting `heating: "1"` via YAML already worked and produced the correct in-car behaviour; only the UI picker did not expose it. Add the missing option so the UI matches what YAML already accepts.

Closes Hyundai-Kia-Connect/kia_uvo#1462. The always-on symptom of Hyundai-Kia-Connect/kia_uvo#1739 is the separate API-side `sideRearMirrorHeating` hardcoding, tracked in Hyundai-Kia-Connect/hyundai_kia_connect_api#1260.

## Change

`custom_components/kia_uvo/services.yaml` — `start_climate.heating` selector: add
`{ label: "Steering Wheel (EU some models), Side and Back Defroster", value: "1" }`,
placed next to the parallel non-EU value `4`.

No duplicate value within the select (now `0/4/1/2/3`). Existing options `0/2/3/4` unchanged.

## Independence from API #1260

This is independent: value `1` is already accepted by the released API library (legacy `heating1: int(heating)`; CCS2 `sideRearMirrorHeating`). API #1260 derives `sideRearMirrorHeating` from `heating` but does not change how `1` is accepted. This PR can ship regardless of #1260's merge state.

## Testing

- `yamllint` + `prettier` (pre-commit) clean.
- YAML parses; no duplicate values in the `heating` select.
- kia_uvo has no unit-test suite; services.yaml selectors are validated by hassfest in CI.