### PR TITLE
fix(climate): unit-aware min/max temp for Fahrenheit vehicles

### DIFF
--- a/custom_components/kia_uvo/climate.py
+++ b/custom_components/kia_uvo/climate.py
@@ -128,18 +128,22 @@ class HyundaiKiaCarClimateControlSwitch(HyundaiKiaConnectEntity, ClimateEntity):
         # TODO: get from lib
         return 0.5
 
-    # TODO: unknown
     @property
     def min_temp(self) -> float:
         """Get the minimum settable temperature."""
-        # TODO: get from lib
+        # TODO: get the exact per-region range from the lib
+        # USA/CA report Fahrenheit; the hardcoded 14-30 °C bounds made the
+        # climate slider unusable (14-30 °F) for those vehicles.
+        if self.temperature_unit == UnitOfTemperature.FAHRENHEIT:
+            return 62
         return 14
 
-    # TODO: unknown
     @property
     def max_temp(self) -> float:
         """Get the maximum settable temperature."""
-        # TODO: get from lib
+        # TODO: get the exact per-region range from the lib
+        if self.temperature_unit == UnitOfTemperature.FAHRENHEIT:
+            return 82
         return 30
 
     @property


### PR DESCRIPTION
## Summary

`climate.py` hardcoded `min_temp=14` / `max_temp=30` — the Celsius range. For vehicles that report Fahrenheit (USA/CA, `air_temperature_unit == "°F"`), the climate entity therefore exposed a **14-30 °F** slider, making `set_temperature` via the entity unusable. Derive the bounds from the existing `temperature_unit` property so Fahrenheit vehicles get 62-82 °F.

Celsius behaviour is unchanged (14-30).

## Change

`custom_components/kia_uvo/climate.py` — `min_temp` / `max_temp` now branch on `self.temperature_unit == UnitOfTemperature.FAHRENHEIT` (62/82) vs Celsius (14/30). Uses the already-populated `vehicle._air_temperature_unit`; no API-library change.

## Scope / caveats

- This is a unit-aware stopgap. The exact per-region range (Kia USA `62-82`, Hyundai USA `62-82`, EU `17-30` half-step, etc.) is still a TODO best sourced from the library; this PR only fixes the broken Fahrenheit case without duplicating the full `temperature_range` table.
- `target_temperature_step` is still hardcoded `0.5` (°C); for °F it should be `1`. Intentionally out of scope here to keep the change surgical — noted for a follow-up.
- No open issue references this exact symptom (the USA °F min/max); it's a latent correctness bug surfaced during a climate-code audit. If a maintainer prefers the fuller lib-sourced range instead, happy to defer to that.

## Testing

kia_uvo has no unit-test suite (HA custom component; HA not importable in CI). Verified:
- `ruff check` + `ruff format` clean.
- `python -m py_compile` clean.
- pre-commit hooks (ruff, codespell, prettier) pass.
- Logic: `temperature_unit` already returns `UnitOfTemperature` from `vehicle._air_temperature_unit`; F → 62/82, C → 14/30 (unchanged).