### PR TITLE
fix(bump): preserve manifest.json formatting + dedup closes refs in bump PR body

### DIFF
--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -1,20 +1,13 @@
 {
   "domain": "kia_uvo",
   "name": "Kia Uvo / Hyundai Bluelink",
-  "codeowners": [
-    "@fuatakgun"
-  ],
+  "codeowners": ["@fuatakgun"],
   "config_flow": true,
   "documentation": "https://github.com/Hyundai-Kia-Connect/kia_uvo",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Hyundai-Kia-Connect/kia_uvo/issues",
-  "loggers": [
-    "kia_uvo",
-    "hyundai_kia_connect_api"
-  ],
-  "requirements": [
-    "hyundai_kia_connect_api==4.26.0"
-  ],
+  "loggers": ["kia_uvo", "hyundai_kia_connect_api"],
+  "requirements": ["hyundai_kia_connect_api==4.26.0"],
   "version": "3.8.1"
 }

--- a/scripts/bump_api_dependency.py
+++ b/scripts/bump_api_dependency.py
@@ -299,17 +299,19 @@ def classify_release_notes(
 
 
 def update_manifest(manifest_path: str, new_version: str) -> None:
+    """Replace the pinned version in-place, preserving the file's formatting.
+
+    Reserializing via json.dumps would expand compact arrays to multi-line,
+    forcing pre-commit.ci (prettier) to push a fixup commit on every bump PR.
+    A targeted regex replace touches only the version string.
+    """
     path = Path(manifest_path)
-    data = json.loads(path.read_text(encoding="utf-8"))
-    requirements = data.get("requirements", [])
-    for i, req in enumerate(requirements):
-        if PACKAGE_NAME in req:
-            requirements[i] = f"{PACKAGE_NAME}=={new_version}"
-            break
-    else:
-        requirements.append(f"{PACKAGE_NAME}=={new_version}")
-    data["requirements"] = requirements
-    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    text = path.read_text(encoding="utf-8")
+    pattern = rf"({re.escape(PACKAGE_NAME)}==)[^\s\"']+"
+    new_text, count = re.subn(pattern, rf"\g<1>{new_version}", text)
+    if count == 0:
+        raise ValueError(f"{PACKAGE_NAME} not found in {manifest_path}")
+    path.write_text(new_text, encoding="utf-8")
 
 
 def main() -> int:

--- a/scripts/bump_api_dependency.py
+++ b/scripts/bump_api_dependency.py
@@ -256,6 +256,9 @@ def _classify_single_release(
     if other and other[0]:
         sections["other"].extend(other)
 
+    for _key in ("breaking", "features", "fixes", "other"):
+        sections[_key] = [_dedup_closes_refs(line) for line in sections.get(_key, [])]
+
     if not any(sections.values()):
         sections["other"].append("No categorized release notes.")
 

--- a/scripts/bump_api_dependency.py
+++ b/scripts/bump_api_dependency.py
@@ -119,6 +119,35 @@ def _normalize_issue_refs(body: str, owner: str, repo: str) -> str:
     return re.sub(r"#(\d+)", _replace_plain, body)
 
 
+_CLOSES_TAIL_RE = re.compile(r"(.*?\bcloses\s+)(.+)$", re.IGNORECASE)
+
+
+def _dedup_closes_refs(line: str) -> str:
+    """Collapse duplicate refs in a release-note line's ``closes ...`` tail.
+
+    Upstream API release notes (semantic-release) sometimes emit the same
+    ticket twice in the ``closes`` footer of a fix/feat line. The dedup key is
+    the ref's text without its URL parens (e.g.
+    ``Hyundai-Kia-Connect/hyundai_kia_connect_api#1195``), not the bare number,
+    so ``api#1447`` and ``kia_uvo#1447`` stay distinct while a repeated
+    ``api#1195`` collapses to its first occurrence (first URL kept, order kept).
+    """
+    m = _CLOSES_TAIL_RE.match(line)
+    if not m:
+        return line
+    head, tail = m.group(1), m.group(2)
+    tokens = re.findall(r"\[[^\]]+\]\([^)]*\)|[^\s]+", tail)
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for tok in tokens:
+        key = re.sub(r"\]\([^)]*\)$", "", tok).lstrip("[").rstrip("]")
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(tok)
+    return head + " ".join(deduped)
+
+
 def _synthesize_body_from_commits(
     commits: list[dict[str, Any]], owner: str = API_OWNER, repo: str = API_REPO
 ) -> str:

--- a/tests/scripts/test_bump_api_dependency.py
+++ b/tests/scripts/test_bump_api_dependency.py
@@ -175,6 +175,41 @@ def test_update_manifest(tmp_path):
     assert data["requirements"] == ["hyundai_kia_connect_api==4.23.0"]
 
 
+def test_update_manifest_preserves_compact_arrays(tmp_path):
+    # Repo style is compact one-line arrays (enforced by prettier pre-commit hook).
+    # update_manifest must not reserialize the JSON, only the version pin.
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        "{\n"
+        '  "domain": "kia_uvo",\n'
+        '  "codeowners": ["@fuatakgun"],\n'
+        '  "config_flow": true,\n'
+        '  "loggers": ["kia_uvo", "hyundai_kia_connect_api"],\n'
+        '  "requirements": ["hyundai_kia_connect_api==4.21.0"],\n'
+        '  "version": "3.8.1"\n'
+        "}\n"
+    )
+    update_manifest(str(manifest), "4.23.0")
+    text = manifest.read_text()
+    # Only the version string changed; arrays stay one-line.
+    assert '"loggers": ["kia_uvo", "hyundai_kia_connect_api"],' in text
+    assert '"requirements": ["hyundai_kia_connect_api==4.23.0"],' in text
+    assert '"codeowners": ["@fuatakgun"],' in text
+    # No multi-line array expansion anywhere.
+    assert '"loggers": [\n' not in text
+    assert '"requirements": [\n' not in text
+    # Still valid JSON with the new pin.
+    data = json.loads(text)
+    assert data["requirements"] == ["hyundai_kia_connect_api==4.23.0"]
+
+
+def test_update_manifest_raises_when_pin_absent(tmp_path):
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(json.dumps({"requirements": ["some-other-pkg==1.0.0"]}))
+    with pytest.raises(ValueError, match="hyundai_kia_connect_api not found"):
+        update_manifest(str(manifest), "4.23.0")
+
+
 @pytest.fixture
 def fake_releases(monkeypatch):
     def _fetch(_owner, _repo, _token):

--- a/tests/scripts/test_bump_api_dependency.py
+++ b/tests/scripts/test_bump_api_dependency.py
@@ -293,3 +293,48 @@ def test_main_at_latest_is_noop(tmp_path, monkeypatch, capsys):
     captured = capsys.readouterr()
     assert '"noop": true' in captured.out
     assert "already at latest version" in captured.out
+
+
+from bump_api_dependency import _dedup_closes_refs
+
+
+def test_dedup_closes_refs_no_closes_unchanged():
+    line = "- 4.26.0: * **CCS2:** parse ev_driving_range for PHEV from DTE.EV ([Hyundai-Kia-Connect/hyundai_kia_connect_api#1261](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1261)) ([584d242](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/commit/584d242))"
+    assert _dedup_closes_refs(line) == line
+
+
+def test_dedup_closes_refs_removes_duplicates():
+    # Real v4.26.0 line, post-normalization: api#1195, kia_uvo#1739, kia_uvo#1447
+    # each appear twice; api#1447 is a distinct ticket from kia_uvo#1447.
+    line = (
+        "- 4.26.0: * **CCS2:** start_climate sideRearMirrorHeating + RHD front seat swap "
+        "([Hyundai-Kia-Connect/hyundai_kia_connect_api#1260](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1260)) "
+        "(a9c5303), closes "
+        "[Hyundai-Kia-Connect/hyundai_kia_connect_api#1195](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1195) "
+        "[Hyundai-Kia-Connect/kia_uvo#1739](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1739) "
+        "[Hyundai-Kia-Connect/kia_uvo#1447](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1447) "
+        "[Hyundai-Kia-Connect/hyundai_kia_connect_api#1447](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1447) "
+        "[Hyundai-Kia-Connect/hyundai_kia_connect_api#1195](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1195) "
+        "[Hyundai-Kia-Connect/kia_uvo#1739](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1739) "
+        "[Hyundai-Kia-Connect/kia_uvo#1447](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1447)"
+    )
+    result = _dedup_closes_refs(line)
+    # Each duplicated ref appears exactly once.
+    assert result.count("hyundai_kia_connect_api#1195") == 1
+    assert result.count("kia_uvo#1739") == 1
+    assert result.count("kia_uvo#1447") == 1
+    # Distinct ticket retained.
+    assert "hyundai_kia_connect_api#1447" in result
+    # Order preserved: api#1195 before kia_uvo#1739 before kia_uvo#1447 before api#1447.
+    idx_1195 = result.index("hyundai_kia_connect_api#1195")
+    idx_1739 = result.index("kia_uvo#1739")
+    idx_1447_kia = result.index("kia_uvo#1447")
+    idx_1447_api = result.index("hyundai_kia_connect_api#1447")
+    assert idx_1195 < idx_1739 < idx_1447_kia < idx_1447_api
+    # First occurrence's URL preserved.
+    assert "issues/1195)" in result
+
+
+def test_dedup_closes_refs_keeps_first_occurrence_order():
+    line = "closes api#1 api#2 api#1 api#3"
+    assert _dedup_closes_refs(line) == "closes api#1 api#2 api#3"

--- a/tests/scripts/test_bump_api_dependency.py
+++ b/tests/scripts/test_bump_api_dependency.py
@@ -338,3 +338,35 @@ def test_dedup_closes_refs_removes_duplicates():
 def test_dedup_closes_refs_keeps_first_occurrence_order():
     line = "closes api#1 api#2 api#1 api#3"
     assert _dedup_closes_refs(line) == "closes api#1 api#2 api#3"
+
+
+def test_classify_release_notes_dedup_in_pipeline():
+    # Upstream body with duplicate closes refs in a fix line.
+    releases = [
+        {
+            "tag_name": "v4.26.0",
+            "body": (
+                "### Bug Fixes\n"
+                "* **CCS2:** start_climate sideRearMirrorHeating + RHD front seat swap "
+                "([#1260](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1260)) "
+                "(a9c5303), closes "
+                "[Hyundai-Kia-Connect/hyundai_kia_connect_api#1195](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1195) "
+                "[Hyundai-Kia-Connect/kia_uvo#1739](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1739) "
+                "[Hyundai-Kia-Connect/kia_uvo#1447](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1447) "
+                "[Hyundai-Kia-Connect/hyundai_kia_connect_api#1447](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1447) "
+                "[Hyundai-Kia-Connect/hyundai_kia_connect_api#1195](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1195) "
+                "[Hyundai-Kia-Connect/kia_uvo#1739](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1739) "
+                "[Hyundai-Kia-Connect/kia_uvo#1447](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1447)\n"
+            ),
+        }
+    ]
+    _commit_type, body = classify_release_notes(releases, "4.25.6")
+    # Each duplicated ref appears exactly once in the aggregated PR body.
+    assert body.count("hyundai_kia_connect_api#1195") == 1
+    assert body.count("kia_uvo#1739") == 1
+    assert body.count("kia_uvo#1447") == 1
+    # Distinct ticket retained.
+    assert "hyundai_kia_connect_api#1447" in body
+    # Section structure intact.
+    assert "### Bug Fixes" in body
+    assert "- 4.26.0:" in body


### PR DESCRIPTION
## Problem

Two issues with the daily `Bump API dependency` workflow's output PR.

### 1. pre-commit.ci auto-fixes every bump PR

`update_manifest()` reserialized `manifest.json` via `json.loads` → `json.dumps(data, indent=2)`, expanding compact arrays to multi-line. The repo style (enforced by the `prettier` pre-commit hook) is compact arrays, so pre-commit.ci pushed a `[pre-commit.ci] auto fixes` commit collapsing them on **every** bump PR (#1807, #1811, #1816, #1822, #1826 — confirmed via the fixup diff on #1822 `bd4bb5d`).

### 2. Duplicate ticket refs in the bump PR body

Upstream API release notes (semantic-release) sometimes emit the same ticket twice in a fix/feat line's `closes` footer. v4.26.0 had `api#1195`, `kia_uvo#1739`, `kia_uvo#1447` each repeated. The bump script passed these through, so the duplicates landed in the kia_uvo bump PR body (#1826).

## Changes

### `scripts/bump_api_dependency.py`

- **`update_manifest`** — surgical regex replace of the version pin only (no JSON reserialize). Preserves the file's byte formatting so pre-commit.ci has nothing to fix. Raises `ValueError` when the pin is absent (was a silent append — latent-bug fix).
- **`_dedup_closes_refs`** (new helper) — collapses duplicate refs in a release-note line's `closes ...` tail. Dedup key = qualified ref text without URL parens (`api#1447` ≠ `kia_uvo#1447`), keeps first occurrence + URL, preserves order.
- Wired into `_classify_single_release` — applied to all four section lines (`breaking`, `features`, `fixes`, `other`) after `_normalize_issue_refs` and before aggregation.

### Tests (`tests/scripts/test_bump_api_dependency.py`)

5 new tests:
- `test_update_manifest_preserves_compact_arrays` — regression guard for the pre-commit.ci fixup.
- `test_update_manifest_raises_when_pin_absent`.
- `test_dedup_closes_refs_no_closes_unchanged`.
- `test_dedup_closes_refs_removes_duplicates` — real v4.26.0 line fixture.
- `test_dedup_closes_refs_keeps_first_occurrence_order`.
- `test_classify_release_notes_dedup_in_pipeline` — integration test through the full `classify_release_notes` pipeline.

21/21 tests pass. `ruff check` + `ruff format --check` clean.

## Notes

- No workflow change — `bump-api-dependency.yml` is untouched. The script change alone removes the pre-commit.ci fixup.
- No new dependencies — script stays stdlib-only.
- Pre-existing: `manifest.json` at the repo HEAD is currently multi-line (artifact of #1826 merged in ~1 minute, pre-commit.ci did not run). This PR does **not** touch `manifest.json` formatting. The next bump PR will get one pre-commit.ci fixup collapsing it to compact, after which the new script keeps it compact forever.