### PR TITLE
fix(climate): start climate with airCtrl on instead of the car's current state

### DIFF
--- a/custom_components/kia_uvo/climate.py
+++ b/custom_components/kia_uvo/climate.py
@@ -97,9 +97,16 @@ class HyundaiKiaCarClimateControlSwitch(HyundaiKiaConnectEntity, ClimateEntity):
         self._attr_unique_id = f"{DOMAIN}_{vehicle.id}_climate_control"
 
         # set the Climate Request to the current actual state of the car
+        #
+        # `climate` is deliberately NOT seeded from air_control_is_on: this
+        # object is only ever used as the payload of a *start* request, and
+        # the backends serialise it as `airCtrl`. Seeding it from the car's
+        # current state meant that whenever climate was off -- i.e. exactly
+        # when you want to start it -- we sent a start request carrying
+        # airCtrl=0 and the car correctly did nothing.
         self.climate_config = ClimateRequestOptions(
             set_temp=self.vehicle.air_temperature,
-            climate=self.vehicle.air_control_is_on,
+            climate=True,
             heating=self.get_internal_heat_int_for_climate_request(),
             defrost=self.vehicle.defrost_is_on,
         )
@@ -212,7 +219,19 @@ class HyundaiKiaCarClimateControlSwitch(HyundaiKiaConnectEntity, ClimateEntity):
     @property
     def supported_features(self) -> int:
         """Supported in-car climate control features."""
-        return ClimateEntityFeature.TARGET_TEMPERATURE
+        return (
+            ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TURN_ON
+            | ClimateEntityFeature.TURN_OFF
+        )
+
+    async def async_turn_on(self) -> None:
+        """Turn the in-car climate control on."""
+        await self.async_set_hvac_mode(HVACMode.HEAT)
+
+    async def async_turn_off(self) -> None:
+        """Turn the in-car climate control off."""
+        await self.async_set_hvac_mode(HVACMode.OFF)
 
     async def async_set_hvac_mode(self, hvac_mode):
         """Set the operation mode of the in-car climate control."""
@@ -224,6 +243,11 @@ class HyundaiKiaCarClimateControlSwitch(HyundaiKiaConnectEntity, ClimateEntity):
                     self.vehicle.id,
                 )
             else:
+                # The car has no heat/cool mode of its own -- it is given a
+                # target temperature and decides -- so HEAT and COOL map onto
+                # the same request. Force airCtrl on: the request may have
+                # been left with climate=False by a previous stop.
+                self.climate_config.climate = True
                 await self.hass.async_add_executor_job(
                     self.vehicle_manager.start_climate,
                     self.vehicle.id,
@@ -233,7 +257,7 @@ class HyundaiKiaCarClimateControlSwitch(HyundaiKiaConnectEntity, ClimateEntity):
             raise HomeAssistantError(
                 f"Climate control not supported by this vehicle: {ex}"
             ) from ex
-        self.coordinator.async_request_refresh()
+        await self.coordinator.async_request_refresh()
         self.async_write_ha_state()
 
     async def async_set_temperature(self, **kwargs):
@@ -253,6 +277,10 @@ class HyundaiKiaCarClimateControlSwitch(HyundaiKiaConnectEntity, ClimateEntity):
                 # Wait, because the car ignores the start_climate command if it comes too fast after stopping
                 # TODO: replace with some more event driven method
                 await self.hass.async_add_executor_job(sleep, 5.0)
+                # Same reason as in async_set_hvac_mode: without this the
+                # stop/start cycle would stop the climate and fail to bring
+                # it back.
+                self.climate_config.climate = True
                 await self.hass.async_add_executor_job(
                     self.vehicle_manager.start_climate,
                     self.vehicle.id,
@@ -262,5 +290,5 @@ class HyundaiKiaCarClimateControlSwitch(HyundaiKiaConnectEntity, ClimateEntity):
                 raise HomeAssistantError(
                     f"Climate control not supported by this vehicle: {ex}"
                 ) from ex
-        self.coordinator.async_request_refresh()
+        await self.coordinator.async_request_refresh()
         self.async_write_ha_state()

--- a/custom_components/kia_uvo/manifest.json
+++ b/custom_components/kia_uvo/manifest.json
@@ -1,20 +1,13 @@
 {
   "domain": "kia_uvo",
   "name": "Kia Uvo / Hyundai Bluelink",
-  "codeowners": [
-    "@fuatakgun"
-  ],
+  "codeowners": ["@fuatakgun"],
   "config_flow": true,
   "documentation": "https://github.com/Hyundai-Kia-Connect/kia_uvo",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Hyundai-Kia-Connect/kia_uvo/issues",
-  "loggers": [
-    "kia_uvo",
-    "hyundai_kia_connect_api"
-  ],
-  "requirements": [
-    "hyundai_kia_connect_api==4.26.0"
-  ],
+  "loggers": ["kia_uvo", "hyundai_kia_connect_api"],
+  "requirements": ["hyundai_kia_connect_api==4.26.0"],
   "version": "3.9.0"
 }

--- a/tests/test_climate_start.py
+++ b/tests/test_climate_start.py
@@ -1,0 +1,109 @@
+"""Tests that starting climate actually asks the car to switch climate on.
+
+``ClimateRequestOptions.climate`` is serialised by the backends as the
+``airCtrl`` field of the start-climate payload. It used to be seeded from
+``vehicle.air_control_is_on``, which is False in exactly the situation where
+a user reaches for the control -- climate is off and they want it on -- so the
+integration sent a start request carrying ``airCtrl=0`` and the car correctly
+did nothing.
+
+This is easy to miss because the neighbouring code paths are unaffected: the
+``kia_uvo.start_climate`` service builds its own options object and callers
+pass ``climate: true`` explicitly, and the climate *switch* entity sends a
+bare ``ClimateRequestOptions()`` whose ``climate=None`` the API library then
+defaults to True. Only the climate entity carried the stale False through.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.components.climate.const import ClimateEntityFeature, HVACMode
+from hyundai_kia_connect_api import Vehicle
+
+from custom_components.kia_uvo.climate import HyundaiKiaCarClimateControlSwitch
+
+
+def _entity(air_control_is_on: bool) -> HyundaiKiaCarClimateControlSwitch:
+    """A climate entity over a vehicle in the given air-control state."""
+    vehicle = Vehicle(id="v1", name="test", model="test")
+    vehicle.air_control_is_on = air_control_is_on
+    # The setter takes a (value, unit) pair.
+    vehicle.air_temperature = (21, "C")
+    vehicle.defrost_is_on = False
+    vehicle.steering_wheel_heater_is_on = False
+    vehicle.back_window_heater_is_on = False
+
+    coordinator = MagicMock()
+    coordinator.async_request_refresh = AsyncMock()
+
+    entity = HyundaiKiaCarClimateControlSwitch(coordinator, vehicle)
+    entity.hass = MagicMock()
+    # Run the executor jobs inline so the recorded call args are the real ones.
+    entity.hass.async_add_executor_job = AsyncMock(
+        side_effect=lambda fn, *args: fn(*args)
+    )
+    entity.async_write_ha_state = MagicMock()
+    return entity
+
+
+async def test_start_requests_air_control_on_while_climate_is_off() -> None:
+    """Starting from the off state must send climate=True, not the stale False."""
+    entity = _entity(air_control_is_on=False)
+
+    await entity.async_set_hvac_mode(HVACMode.HEAT)
+
+    _vehicle_id, options = entity.vehicle_manager.start_climate.call_args.args
+    assert options.climate is True
+
+
+async def test_cool_also_requests_air_control_on() -> None:
+    """The car has no mode of its own, so COOL is the same request as HEAT."""
+    entity = _entity(air_control_is_on=False)
+
+    await entity.async_set_hvac_mode(HVACMode.COOL)
+
+    _vehicle_id, options = entity.vehicle_manager.start_climate.call_args.args
+    assert options.climate is True
+
+
+async def test_off_stops_climate_and_does_not_start_it() -> None:
+    """Turning off must reach stop_climate only."""
+    entity = _entity(air_control_is_on=True)
+
+    await entity.async_set_hvac_mode(HVACMode.OFF)
+
+    entity.vehicle_manager.stop_climate.assert_called_once()
+    entity.vehicle_manager.start_climate.assert_not_called()
+
+
+async def test_temperature_change_while_on_restarts_with_air_control_on() -> None:
+    """The stop/start cycle must bring climate back up, not just stop it.
+
+    This path happened to be safe before the fix, because it can only run
+    while climate is already on and the request was seeded True in that case.
+    Pinned so the invariant survives future edits.
+    """
+    entity = _entity(air_control_is_on=True)
+
+    await entity.async_set_temperature(temperature=23)
+
+    entity.vehicle_manager.stop_climate.assert_called_once()
+    _vehicle_id, options = entity.vehicle_manager.start_climate.call_args.args
+    assert options.climate is True
+    assert options.set_temp == 23
+
+
+async def test_turn_on_off_are_supported() -> None:
+    """Without these flags climate.turn_on/turn_off reject the entity."""
+    entity = _entity(air_control_is_on=False)
+
+    assert entity.supported_features & ClimateEntityFeature.TURN_ON
+    assert entity.supported_features & ClimateEntityFeature.TURN_OFF
+
+
+async def test_refresh_is_awaited() -> None:
+    """async_request_refresh is a coroutine; not awaiting it never scheduled it."""
+    entity = _entity(air_control_is_on=False)
+
+    await entity.async_set_hvac_mode(HVACMode.HEAT)
+
+    entity.coordinator.async_request_refresh.assert_awaited_once()


### PR DESCRIPTION
## The bug

Setting an HVAC mode on `climate.<car>_climate_control` does nothing on the car. Reproduced on a 2026 Ioniq 5 (USA / Bluelink), where the Bluelink app starts climate fine and the HA entity silently no-ops.

The entity builds its `ClimateRequestOptions` once in `__init__` and seeds `climate` from the car's *current* state:

```python
self.climate_config = ClimateRequestOptions(
    set_temp=self.vehicle.air_temperature,
    climate=self.vehicle.air_control_is_on,   # False whenever climate is off
    ...
)
```

`async_set_hvac_mode` then passes that object through unchanged, and the backends serialise the field as `airCtrl` — e.g. `HyundaiBlueLinkApiUSA.start_climate`:

```python
if options.climate is None:
    options.climate = True
...
data = {"airCtrl": int(options.climate), ...}
```

So whenever climate is off — precisely when you want to start it — we send a start-climate request carrying `airCtrl=0`, and the car correctly does nothing. The library's default only applies when `climate` is `None`; a literal `False` sails straight through.

This is easy to miss, because the neighbouring paths are unaffected:

- the `kia_uvo.start_climate` service builds its own options and callers pass `climate: true`
- the climate **switch** entity sends a bare `ClimateRequestOptions()` → `climate=None` → library defaults it to `True`

Only the climate **entity** carried the stale `False`.

## The fix

`climate` is no longer seeded from `air_control_is_on`. The object is only ever used as the payload of a *start* request, so `True` is the only sensible value; it is also set explicitly before each `start_climate` so the invariant is visible at the call site.

Two related fixes in the same entity:

- **`supported_features` gains `TURN_ON`/`TURN_OFF`** (plus `async_turn_on`/`async_turn_off`). Without the flags the generic `climate.turn_on` / `climate.turn_off` services refuse the entity and the thermostat card's power button is inert.
- **`coordinator.async_request_refresh()` is now awaited.** It is a coroutine, so the bare call never scheduled the refresh and logged `RuntimeWarning: coroutine 'DataUpdateCoordinator.async_request_refresh' was never awaited`; entity state stayed stale after every command.

## Tests

Adds `tests/test_climate_start.py`. Four of the six tests fail on `master` and pass with this change; the other two pin invariants that already held. Full suite: 58 passed.

## Notes

- No change to the `start_climate` service or the switch entity — both already worked.
- The `set_temperature` restart path was in fact safe before this change (it can only run while climate is already on, where the seed was `True`); the explicit assignment there is a guard, not a live bug fix.
- Unrelated to #1821, which fixed the Fahrenheit min/max range and is already on master.
