### PR TITLE
fix: keep EV charging power sensor available

### DIFF
--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -470,6 +470,15 @@ async def async_setup_entry(
                 # next reload. Always create; None -> HA `unknown`, the real
                 # SoC arrives on the next poll. See #1803.
                 create = True
+            elif description.key == "ev_charging_power":
+                # Charging power is transient and usually None at setup while
+                # the vehicle is unplugged. Create the sensor for electrified
+                # vehicles so a later coordinator poll can publish the value
+                # without requiring an integration reload.
+                create = (
+                    vehicle.engine_type in (ENGINE_TYPES.EV, ENGINE_TYPES.PHEV)
+                    or vehicle.ev_charging_power is not None
+                )
             elif description.key.startswith("tire_pressure_"):
                 # Transient like _air_temperature above: some backends (AU/NZ)
                 # report the TPMS no-data sentinel whenever the car is parked

--- a/tests/test_ev_charging_power_sensor_creation.py
+++ b/tests/test_ev_charging_power_sensor_creation.py
@@ -1,0 +1,59 @@
+"""Tests for transient EV charging-power sensor creation."""
+
+from unittest.mock import MagicMock
+
+from hyundai_kia_connect_api import Vehicle
+from hyundai_kia_connect_api.const import ENGINE_TYPES
+
+from custom_components.kia_uvo import sensor as sensor_platform
+from custom_components.kia_uvo.const import DOMAIN
+
+
+async def _charging_power_entity(engine_type: ENGINE_TYPES | None, value: float | None):
+    vehicle = Vehicle(id="v1", name="test", model="test")
+    vehicle.engine_type = engine_type
+    vehicle.ev_charging_power = value
+
+    coordinator = MagicMock()
+    coordinator.vehicle_manager.vehicles = {"v1": vehicle}
+    hass = MagicMock()
+    config_entry = MagicMock()
+    config_entry.unique_id = "uid"
+    hass.data = {DOMAIN: {"uid": coordinator}}
+    created = []
+
+    await sensor_platform.async_setup_entry(hass, config_entry, created.extend)
+
+    return next(
+        (
+            entity
+            for entity in created
+            if getattr(entity, "entity_description", None) is not None
+            and entity.entity_description.key == "ev_charging_power"
+        ),
+        None,
+    )
+
+
+async def test_ev_creates_charging_power_sensor_while_unplugged() -> None:
+    """An unplugged EV still needs an entity for later charging updates."""
+    entity = await _charging_power_entity(ENGINE_TYPES.EV, None)
+    assert entity is not None
+    assert entity.native_value is None
+
+
+async def test_phev_creates_charging_power_sensor_while_unplugged() -> None:
+    """An unplugged PHEV also retains the transient sensor."""
+    assert await _charging_power_entity(ENGINE_TYPES.PHEV, None) is not None
+
+
+async def test_ice_does_not_create_empty_charging_power_sensor() -> None:
+    """ICE vehicles should not gain an unsupported charging-power entity."""
+    assert await _charging_power_entity(ENGINE_TYPES.ICE, None) is None
+
+
+async def test_reported_power_creates_sensor_when_engine_type_is_unknown() -> None:
+    """Preserve discovery for backends that report power without engine type."""
+    entity = await _charging_power_entity(None, 7.2)
+    assert entity is not None
+    assert entity.native_value == 7.2


### PR DESCRIPTION
### Summary

- always create the EV charging-power sensor for EV and PHEV vehicles
- retain value-based discovery for backends that report charging power without
  an engine type
- keep unsupported empty charging-power entities off ICE vehicles
- add regression coverage for EV, PHEV, ICE, and unknown-engine scenarios

### Background

Charging power is transient and is normally `None` when a vehicle is unplugged.
The sensor platform currently creates most entities only when their value is
non-`None` during integration setup. This means the charging-power sensor is not
loaded when Home Assistant starts while the vehicle is unplugged. A later
coordinator poll can contain a valid power reading, but no entity exists to
publish it; reloading the integration while charging makes it appear.

The value was confirmed in an anonymized Hyundai USA payload under
`vehicleStatus.evStatus.batteryStndChrgPower`, while the registered Home
Assistant entity remained unavailable. After creating the sensor based on the
stable EV/PHEV capability, the entity changed to the current kW value at setup
and can receive subsequent coordinator updates normally. When no power is
reported, Home Assistant represents the sensor as unknown rather than removing
it from the loaded platform.

### Testing

- EV with `None` power: sensor is created with an unknown value
- PHEV with `None` power: sensor is created
- ICE with `None` power: sensor is not created
- unknown engine type with reported power: existing discovery behavior remains
- all four scenarios passed against Home Assistant 2026.7.4 with the patched
  integration
- `ruff check`, `ruff format --check`, and `git diff --check` passed

### Privacy

The tests use synthetic values and identifiers. No VIN, account identifier,
coordinates, authentication data, or raw personal vehicle payload is included.
