### PR TITLE
fix(sensor): keep EV target-charge-range sensors available (#1842)

### DIFF
--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import date
 from typing import Final
 
@@ -31,8 +33,21 @@ from .entity import HyundaiKiaConnectEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
-    SensorEntityDescription(
+
+@dataclass
+class HyundaiKiaSensorEntityDescription(SensorEntityDescription):
+    """A class that describes custom sensor entities."""
+
+    exists: Callable[[Vehicle], bool] | None = None
+
+
+def _is_electrified(vehicle: Vehicle) -> bool:
+    """Return True for BEV and PHEV vehicles."""
+    return vehicle.engine_type in (ENGINE_TYPES.EV, ENGINE_TYPES.PHEV)
+
+
+SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaSensorEntityDescription, ...]] = (
+    HyundaiKiaSensorEntityDescription(
         key="_total_driving_range",
         translation_key="total_driving_range",
         icon="mdi:road-variant",
@@ -40,7 +55,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         native_unit_of_measurement=DYNAMIC_UNIT,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="_odometer",
         translation_key="odometer",
         icon="mdi:speedometer",
@@ -48,7 +63,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.DISTANCE,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="_last_service_distance",
         translation_key="last_service_distance",
         icon="mdi:car-wrench",
@@ -56,7 +71,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         native_unit_of_measurement=DYNAMIC_UNIT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="_next_service_distance",
         translation_key="next_service_distance",
         icon="mdi:car-wrench",
@@ -64,50 +79,58 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         native_unit_of_measurement=DYNAMIC_UNIT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="car_battery_percentage",
         translation_key="car_battery_percentage",
         icon="mdi:car-battery",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
+        # The 12V SoC is transient — None while the telematics unit
+        # is asleep, after a 12V reset, or when the status payload
+        # omits it. Don't gate creation on it: a None at setup (e.g.
+        # a version-update reload) means the entity isn't yielded and
+        # HA marks it "no longer provided", with no return until the
+        # next reload. Always create; None -> HA `unknown`, the real
+        # SoC arrives on the next poll. See #1803.
+        exists=lambda _: True,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="last_updated_at",
         translation_key="last_updated_at",
         icon="mdi:update",
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="last_scanned_at",
         translation_key="last_scanned_at",
         icon="mdi:cloud-search",
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_battery_percentage",
         translation_key="ev_battery_percentage",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_battery_soh_percentage",
         translation_key="ev_battery_soh_percentage",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_battery_remain",
         translation_key="ev_battery_remain",
         native_unit_of_measurement=UnitOfEnergy.KILO_JOULE,
         device_class=SensorDeviceClass.ENERGY_STORAGE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_battery_capacity",
         translation_key="ev_battery_capacity",
         native_unit_of_measurement=UnitOfEnergy.KILO_JOULE,
@@ -115,7 +138,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="_ev_driving_range",
         translation_key="ev_driving_range",
         icon="mdi:road-variant",
@@ -123,65 +146,90 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         native_unit_of_measurement=DYNAMIC_UNIT,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="_fuel_driving_range",
         translation_key="fuel_driving_range",
         icon="mdi:road-variant",
         device_class=SensorDeviceClass.DISTANCE,
         native_unit_of_measurement=DYNAMIC_UNIT,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="fuel_level",
         translation_key="fuel_level",
         native_unit_of_measurement=PERCENTAGE,
         icon="mdi:fuel",
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="_air_temperature",
         translation_key="air_temperature",
         native_unit_of_measurement=DYNAMIC_UNIT,
         device_class=SensorDeviceClass.TEMPERATURE,
+        # The setpoint is transient — it is None while climate is off
+        # (USA returns airTemp.value "OFF"), so don't gate on it. Gate
+        # on climate presence (air_control_is_on, the same signal the
+        # climate entity uses) to avoid creating an unusable sensor on
+        # vehicles that report no climate. A None setpoint -> HA
+        # `unknown`; the real setpoint arrives on the next poll.
+        exists=lambda vehicle: (
+            vehicle.air_control_is_on is not None
+            or vehicle._air_temperature is not None
+        ),
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_estimated_current_charge_duration",
         translation_key="ev_estimated_current_charge_duration",
         icon="mdi:ev-station",
         native_unit_of_measurement=UnitOfTime.MINUTES,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_estimated_fast_charge_duration",
         translation_key="ev_estimated_fast_charge_duration",
         icon="mdi:ev-station",
         native_unit_of_measurement=UnitOfTime.MINUTES,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_estimated_portable_charge_duration",
         translation_key="ev_estimated_portable_charge_duration",
         icon="mdi:ev-station",
         native_unit_of_measurement=UnitOfTime.MINUTES,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_estimated_station_charge_duration",
         translation_key="ev_estimated_station_charge_duration",
         icon="mdi:ev-station",
         native_unit_of_measurement=UnitOfTime.MINUTES,
     ),
-    SensorEntityDescription(
+    # Target charge range is transient — None at setup when the car is
+    # asleep, telematics omits dte.rangeByFuel.totalAvailableRange, or
+    # targetSOClist has a single entry (one of the two indices is then
+    # absent). Value-gating here drops the entity permanently ("no longer
+    # provided") on a version-update reload, and it only returns on a
+    # manual reload while the value happens to be present. Gate on the
+    # stable EV/PHEV capability instead so a later coordinator poll can
+    # publish the range. None -> HA `unknown` until the next poll. See
+    # #1842. The same gate applies to both sensors below.
+    HyundaiKiaSensorEntityDescription(
         key="_ev_target_range_charge_AC",
         translation_key="ev_target_range_charge_ac",
         icon="mdi:ev-station",
         device_class=SensorDeviceClass.DISTANCE,
         native_unit_of_measurement=DYNAMIC_UNIT,
+        exists=lambda vehicle: (
+            _is_electrified(vehicle) or vehicle._ev_target_range_charge_AC is not None
+        ),
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="_ev_target_range_charge_DC",
         translation_key="ev_target_range_charge_dc",
         icon="mdi:ev-station",
         device_class=SensorDeviceClass.DISTANCE,
         native_unit_of_measurement=DYNAMIC_UNIT,
+        exists=lambda vehicle: (
+            _is_electrified(vehicle) or vehicle._ev_target_range_charge_DC is not None
+        ),
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="total_power_consumed",
         translation_key="total_power_consumed",
         icon="mdi:car-electric",
@@ -189,7 +237,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="total_power_regenerated",
         translation_key="total_power_regenerated",
         icon="mdi:car-electric",
@@ -198,89 +246,96 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         state_class=SensorStateClass.TOTAL,
     ),
     # Need to remove km hard coding.  Underlying API needs this fixed first.  EU always does KM.
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="power_consumption_30d",
         translation_key="power_consumption_30d",
         icon="mdi:car-electric",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=f"{UnitOfEnergy.WATT_HOUR}/km",
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="front_left_seat_status",
         translation_key="front_left_seat_status",
         icon="mdi:car-seat-heater",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="front_right_seat_status",
         translation_key="front_right_seat_status",
         icon="mdi:car-seat-heater",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="rear_left_seat_status",
         translation_key="rear_left_seat_status",
         icon="mdi:car-seat-heater",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="rear_right_seat_status",
         translation_key="rear_right_seat_status",
         icon="mdi:car-seat-heater",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="_geocode_name",
         translation_key="geocode_name",
         icon="mdi:map",
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="dtc_count",
         translation_key="dtc_count",
         icon="mdi:alert-circle",
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_first_departure_time",
         translation_key="ev_first_departure_time",
         icon="mdi:clock-outline",
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_second_departure_time",
         translation_key="ev_second_departure_time",
         icon="mdi:clock-outline",
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_off_peak_start_time",
         translation_key="ev_off_peak_start_time",
         icon="mdi:clock-outline",
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_off_peak_end_time",
         translation_key="ev_off_peak_end_time",
         icon="mdi:clock-outline",
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_charging_current",
         translation_key="ev_charging_current",
         icon="mdi:lightning-bolt-circle",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.POWER_FACTOR,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_charging_power",
         translation_key="ev_charging_power",
         icon="mdi:flash",
         native_unit_of_measurement=UnitOfPower.KILO_WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        # Charging power is transient and usually None at setup while
+        # the vehicle is unplugged. Create the sensor for electrified
+        # vehicles so a later coordinator poll can publish the value
+        # without requiring an integration reload.
+        exists=lambda vehicle: (
+            _is_electrified(vehicle) or vehicle.ev_charging_power is not None
+        ),
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="VIN",
         translation_key="vehicle_identification_number",
         icon="mdi:identifier",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="_outside_temperature",
         translation_key="outside_temperature",
         icon="mdi:thermometer",
@@ -289,13 +344,13 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         native_unit_of_measurement=DYNAMIC_UNIT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="engine_type",
         translation_key="engine_type",
         icon="mdi:engine",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_battery_chiller_rpm",
         translation_key="ev_battery_chiller_rpm",
         icon="mdi:fan",
@@ -303,19 +358,19 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         native_unit_of_measurement="rpm",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_first_departure_days",
         translation_key="ev_first_departure_days",
         icon="mdi:calendar-clock",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_second_departure_days",
         translation_key="ev_second_departure_days",
         icon="mdi:calendar-clock",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="_ev_first_departure_climate_temperature",
         translation_key="ev_first_departure_climate_temperature",
         icon="mdi:thermometer",
@@ -324,7 +379,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         native_unit_of_measurement=DYNAMIC_UNIT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="_ev_second_departure_climate_temperature",
         translation_key="ev_second_departure_climate_temperature",
         icon="mdi:thermometer",
@@ -333,7 +388,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         native_unit_of_measurement=DYNAMIC_UNIT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_battery_pack_voltage",
         translation_key="ev_battery_pack_voltage",
         icon="mdi:car-battery",
@@ -342,7 +397,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_battery_temperature_min",
         translation_key="ev_battery_temperature_min",
         icon="mdi:thermometer-low",
@@ -351,7 +406,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         native_unit_of_measurement=DYNAMIC_UNIT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_battery_temperature_max",
         translation_key="ev_battery_temperature_max",
         icon="mdi:thermometer-high",
@@ -360,7 +415,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         native_unit_of_measurement=DYNAMIC_UNIT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_battery_water_temperature",
         translation_key="ev_battery_water_temperature",
         icon="mdi:thermometer-water",
@@ -369,7 +424,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         native_unit_of_measurement=DYNAMIC_UNIT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_power_consumption_air_conditioning",
         translation_key="ev_power_consumption_air_conditioning",
         icon="mdi:air-conditioner",
@@ -378,7 +433,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_power_consumption_battery_cooling",
         translation_key="ev_power_consumption_battery_cooling",
         icon="mdi:snowflake",
@@ -387,7 +442,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="ev_power_consumption_battery_heater",
         translation_key="ev_power_consumption_battery_heater",
         icon="mdi:radiator",
@@ -396,42 +451,68 @@ SENSOR_DESCRIPTIONS: Final[tuple[SensorEntityDescription, ...]] = (
         native_unit_of_measurement=UnitOfPower.WATT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="location_last_updated_at",
         translation_key="location_last_updated_at",
         icon="mdi:map-clock",
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    SensorEntityDescription(
+    # Transient like _air_temperature above: some backends (AU/NZ)
+    # report the TPMS no-data sentinel whenever the car is parked
+    # — nearly always the case at setup — so don't gate on the
+    # value. The parsed unit is the capability signal: non-None
+    # exactly for direct-TPMS vehicles (known PressureUnit), None
+    # for indirect TPMS (PressureUnit 3, e.g. KONA — #1786) and
+    # old-protocol vehicles, which never report a numeric
+    # pressure. A None pressure -> HA `unknown` until a poll
+    # catches the car driving. The same gate applies to all four
+    # tire_pressure_* sensors below.
+    HyundaiKiaSensorEntityDescription(
         key="tire_pressure_front_left",
         translation_key="tire_pressure_front_left",
         device_class=SensorDeviceClass.PRESSURE,
         native_unit_of_measurement=DYNAMIC_UNIT,
         state_class=SensorStateClass.MEASUREMENT,
+        exists=lambda vehicle: (
+            vehicle.tire_pressure_front_left is not None
+            or vehicle.tire_pressure_unit is not None
+        ),
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="tire_pressure_front_right",
         translation_key="tire_pressure_front_right",
         device_class=SensorDeviceClass.PRESSURE,
         native_unit_of_measurement=DYNAMIC_UNIT,
         state_class=SensorStateClass.MEASUREMENT,
+        exists=lambda vehicle: (
+            vehicle.tire_pressure_front_right is not None
+            or vehicle.tire_pressure_unit is not None
+        ),
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="tire_pressure_rear_left",
         translation_key="tire_pressure_rear_left",
         device_class=SensorDeviceClass.PRESSURE,
         native_unit_of_measurement=DYNAMIC_UNIT,
         state_class=SensorStateClass.MEASUREMENT,
+        exists=lambda vehicle: (
+            vehicle.tire_pressure_rear_left is not None
+            or vehicle.tire_pressure_unit is not None
+        ),
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="tire_pressure_rear_right",
         translation_key="tire_pressure_rear_right",
         device_class=SensorDeviceClass.PRESSURE,
         native_unit_of_measurement=DYNAMIC_UNIT,
         state_class=SensorStateClass.MEASUREMENT,
+        exists=lambda vehicle: (
+            vehicle.tire_pressure_rear_right is not None
+            or vehicle.tire_pressure_unit is not None
+        ),
     ),
-    SensorEntityDescription(
+    HyundaiKiaSensorEntityDescription(
         key="drive_mode",
         translation_key="drive_mode",
         icon="mdi:car-cog",
@@ -450,68 +531,11 @@ async def async_setup_entry(
     for vehicle_id in coordinator.vehicle_manager.vehicles:
         vehicle: Vehicle = coordinator.vehicle_manager.vehicles[vehicle_id]
         for description in SENSOR_DESCRIPTIONS:
-            if description.key == "_air_temperature":
-                # The setpoint is transient — it is None while climate is off
-                # (USA returns airTemp.value "OFF"), so don't gate on it. Gate
-                # on climate presence (air_control_is_on, the same signal the
-                # climate entity uses) to avoid creating an unusable sensor on
-                # vehicles that report no climate. A None setpoint -> HA
-                # `unknown`; the real setpoint arrives on the next poll.
-                create = (
-                    vehicle.air_control_is_on is not None
-                    or vehicle._air_temperature is not None
-                )
-            elif description.key == "car_battery_percentage":
-                # The 12V SoC is transient — None while the telematics unit
-                # is asleep, after a 12V reset, or when the status payload
-                # omits it. Don't gate creation on it: a None at setup (e.g.
-                # a version-update reload) means the entity isn't yielded and
-                # HA marks it "no longer provided", with no return until the
-                # next reload. Always create; None -> HA `unknown`, the real
-                # SoC arrives on the next poll. See #1803.
-                create = True
-            elif description.key == "ev_charging_power":
-                # Charging power is transient and usually None at setup while
-                # the vehicle is unplugged. Create the sensor for electrified
-                # vehicles so a later coordinator poll can publish the value
-                # without requiring an integration reload.
-                create = (
-                    vehicle.engine_type in (ENGINE_TYPES.EV, ENGINE_TYPES.PHEV)
-                    or vehicle.ev_charging_power is not None
-                )
-            elif description.key in (
-                "_ev_target_range_charge_AC",
-                "_ev_target_range_charge_DC",
-            ):
-                # Target charge range is transient — None at setup when the car
-                # is asleep, telematics omits dte.rangeByFuel.totalAvailableRange,
-                # or targetSOClist has a single entry (one of the two indices is
-                # then absent). Value-gating here drops the entity permanently
-                # ("no longer provided") on a version-update reload, and it only
-                # returns on a manual reload while the value happens to be
-                # present. Gate on the stable EV/PHEV capability instead so a
-                # later coordinator poll can publish the range. None -> HA
-                # `unknown` until the next poll. See kia_uvo #1842.
-                create = (
-                    vehicle.engine_type in (ENGINE_TYPES.EV, ENGINE_TYPES.PHEV)
-                    or getattr(vehicle, description.key, None) is not None
-                )
-            elif description.key.startswith("tire_pressure_"):
-                # Transient like _air_temperature above: some backends (AU/NZ)
-                # report the TPMS no-data sentinel whenever the car is parked
-                # — nearly always the case at setup — so don't gate on the
-                # value. The parsed unit is the capability signal: non-None
-                # exactly for direct-TPMS vehicles (known PressureUnit), None
-                # for indirect TPMS (PressureUnit 3, e.g. KONA — #1786) and
-                # old-protocol vehicles, which never report a numeric
-                # pressure. A None pressure -> HA `unknown` until a poll
-                # catches the car driving.
-                create = (
-                    getattr(vehicle, description.key, None) is not None
-                    or vehicle.tire_pressure_unit is not None
-                )
-            else:
-                create = getattr(vehicle, description.key, None) is not None
+            create = (
+                description.exists(vehicle)
+                if description.exists is not None
+                else getattr(vehicle, description.key, None) is not None
+            )
             if create:
                 entities.append(
                     HyundaiKiaConnectSensor(coordinator, description, vehicle)

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -479,6 +479,23 @@ async def async_setup_entry(
                     vehicle.engine_type in (ENGINE_TYPES.EV, ENGINE_TYPES.PHEV)
                     or vehicle.ev_charging_power is not None
                 )
+            elif description.key in (
+                "_ev_target_range_charge_AC",
+                "_ev_target_range_charge_DC",
+            ):
+                # Target charge range is transient — None at setup when the car
+                # is asleep, telematics omits dte.rangeByFuel.totalAvailableRange,
+                # or targetSOClist has a single entry (one of the two indices is
+                # then absent). Value-gating here drops the entity permanently
+                # ("no longer provided") on a version-update reload, and it only
+                # returns on a manual reload while the value happens to be
+                # present. Gate on the stable EV/PHEV capability instead so a
+                # later coordinator poll can publish the range. None -> HA
+                # `unknown` until the next poll. See kia_uvo #1842.
+                create = (
+                    vehicle.engine_type in (ENGINE_TYPES.EV, ENGINE_TYPES.PHEV)
+                    or getattr(vehicle, description.key, None) is not None
+                )
             elif description.key.startswith("tire_pressure_"):
                 # Transient like _air_temperature above: some backends (AU/NZ)
                 # report the TPMS no-data sentinel whenever the car is parked

--- a/tests/test_ev_target_range_sensor_creation.py
+++ b/tests/test_ev_target_range_sensor_creation.py
@@ -1,0 +1,77 @@
+"""Tests for transient EV target-charge-range sensor creation."""
+
+from unittest.mock import MagicMock
+
+from hyundai_kia_connect_api import Vehicle
+from hyundai_kia_connect_api.const import ENGINE_TYPES
+
+from custom_components.kia_uvo import sensor as sensor_platform
+from custom_components.kia_uvo.const import DOMAIN
+
+_TARGET_RANGE_KEYS = ("_ev_target_range_charge_AC", "_ev_target_range_charge_DC")
+
+
+async def _target_range_entity(
+    engine_type: ENGINE_TYPES | None,
+    values: dict[str, float | None],
+) -> list:
+    """Return the created target-range entities (AC + DC) for the vehicle."""
+    vehicle = Vehicle(id="v1", name="test", model="test")
+    vehicle.engine_type = engine_type
+    for key, value in values.items():
+        # sensor.py reads the private dataclass field directly via getattr.
+        setattr(vehicle, key, value)
+
+    coordinator = MagicMock()
+    coordinator.vehicle_manager.vehicles = {"v1": vehicle}
+    hass = MagicMock()
+    config_entry = MagicMock()
+    config_entry.unique_id = "uid"
+    hass.data = {DOMAIN: {"uid": coordinator}}
+    created = []
+
+    await sensor_platform.async_setup_entry(hass, config_entry, created.extend)
+
+    return [
+        e
+        for e in created
+        if getattr(e, "entity_description", None) is not None
+        and e.entity_description.key in _TARGET_RANGE_KEYS
+    ]
+
+
+async def test_ev_creates_target_range_sensors_when_value_absent() -> None:
+    """An asleep EV still needs entities for later target-range polls. See #1842."""
+    entities = await _target_range_entity(
+        ENGINE_TYPES.EV, {k: None for k in _TARGET_RANGE_KEYS}
+    )
+    keys = {e.entity_description.key for e in entities}
+    assert keys == set(_TARGET_RANGE_KEYS)
+    assert all(e.native_value is None for e in entities)
+
+
+async def test_phev_creates_target_range_sensors_when_value_absent() -> None:
+    """A PHEV also retains the transient target-range sensors."""
+    entities = await _target_range_entity(
+        ENGINE_TYPES.PHEV, {k: None for k in _TARGET_RANGE_KEYS}
+    )
+    assert {e.entity_description.key for e in entities} == set(_TARGET_RANGE_KEYS)
+
+
+async def test_ice_does_not_create_target_range_sensors() -> None:
+    """ICE vehicles should not gain unsupported target-charge-range entities."""
+    assert (
+        await _target_range_entity(
+            ENGINE_TYPES.ICE, {k: None for k in _TARGET_RANGE_KEYS}
+        )
+        == []
+    )
+
+
+async def test_reported_range_creates_sensors_when_engine_type_is_unknown() -> None:
+    """Preserve discovery for backends that report target range without engine type."""
+    values = {"_ev_target_range_charge_AC": 591, "_ev_target_range_charge_DC": 525}
+    entities = await _target_range_entity(None, values)
+    by_key = {e.entity_description.key: e for e in entities}
+    assert by_key["_ev_target_range_charge_AC"].native_value == 591
+    assert by_key["_ev_target_range_charge_DC"].native_value == 525


### PR DESCRIPTION
## Summary

The **Target Range of Charge AC** and **Target Range of Charge DC** sensors became unavailable for some EU Hyundai/Kia EVs after the update to 3.10.x (Hyundai-Kia-Connect/kia_uvo#1842).

This gates those two sensors on the stable EV/PHEV capability instead of on their value being non-`None` at setup, mirroring the charging-power sensor (#1835) and the 12V battery sensor (#1803).

## Root cause

Both sensors fall into the generic `else` branch of `async_setup_entry`:

```python
else:
    create = getattr(vehicle, description.key, None) is not None
```

The range is derived from `evStatus.reservChargeInfos.targetSOClist[i].dte.rangeByFuel.totalAvailableRange.value`. That value is **transient** — it is `None` at setup when:

- the telematics unit is asleep / not reporting `dte.rangeByFuel`,
- the car is parked and the backend omits the range block,
- or `targetSOClist` has a single entry, so one of the two hardcoded indices (`.0.` / `.1.`) is absent.

When a version-update reload lands while the value is `None`, the entity is **not yielded**, HA marks it "no longer provided", and it only comes back on a manual reload that happens to coincide with the value being present. This is the same bug class as the 12V battery sensor (#1803) and the EV charging-power sensor (#1835).

The API-library parsing is **unchanged** across `v4.25.6 → v4.26.5` (diffed `KiaUvoApiEU.py` / `Vehicle.py` — no edits to the `targetSOClist` read path). The regression is the HA-side value-gated creation, not parsing.

## Fix

Gate the two target-charge-range sensors on the stable EV/PHEV capability with the existing value-based fallback — identical pattern to the charging-power sensor (#1835) — now expressed as an `exists` predicate on the sensor description (the same pattern the binary_sensor platform uses for `is_on`):

```python
HyundaiKiaSensorEntityDescription(
    key="_ev_target_range_charge_AC",
    ...
    exists=lambda vehicle: (
        _is_electrified(vehicle) or vehicle._ev_target_range_charge_AC is not None
    ),
),
```

`async_setup_entry` consumes it with a single check (`description.exists(vehicle)` when defined, otherwise the default value gate), replacing the per-key elif cascade. A `None` value → HA `unknown` until the next coordinator poll publishes the range. ICE/HEV vehicles are unaffected.

## Scope

- **In:** EV and PHEV vehicles (which report a target charge range).
- **Out:** ICE / HEV (do not report this range).
- Applies uniformly to all regions that parse `targetSOClist` (EU / USA / AU / CN / IN share the same `else` gate); strictly more permissive only for EV/PHEV, no regression for other powertrains.

## Secondary symptom (not fixed here)

One commenter (Kona EV) reports the AC and DC values are equal to the current range. Their diagnostics payload shows both `targetSOClist` entries carry the same `totalAvailableRange` from the backend — i.e. the car's API returns the current range for both plug types. The parser reads the field correctly; this is car-side data, not a parsing bug, and is out of scope for this PR.

## Testing

- `tests/test_ev_target_range_sensor_creation.py` — regression coverage mirroring the charging-power tests:
  - EV with `None` range → both sensors created, value `None` (→ HA `unknown`)
  - PHEV with `None` range → both sensors created
  - ICE with `None` range → neither created
  - unknown engine type with a reported range → sensors created with the reported value
- Full local suite: 66 passed (Home Assistant + pytest-asyncio, Python 3.13).
- `ruff check` and `ruff format --check` clean on all tracked `.py`.
- No change to `manifest.json`, `strings.json`, or `services.yaml` → hassfest / HACS unaffected.
