### PR TITLE
fix(climate): route climate actions through coordinator action path

### DIFF
--- a/custom_components/kia_uvo/climate.py
+++ b/custom_components/kia_uvo/climate.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from time import sleep
 from typing import ClassVar
 
 from homeassistant.components.climate import ClimateEntity, ClimateEntityDescription
@@ -15,10 +15,8 @@ from homeassistant.components.climate.const import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from hyundai_kia_connect_api import ClimateRequestOptions, Vehicle, VehicleManager
-from hyundai_kia_connect_api.exceptions import UnsupportedControlError
+from hyundai_kia_connect_api import ClimateRequestOptions, Vehicle
 
 from .const import DOMAIN
 from .coordinator import HyundaiKiaConnectDataUpdateCoordinator
@@ -47,7 +45,6 @@ PARALLEL_UPDATES = 1
 class HyundaiKiaCarClimateControlSwitch(HyundaiKiaConnectEntity, ClimateEntity):
     """Hyundai / Kia Connect Car Climate Control."""
 
-    vehicle_manager: VehicleManager
     vehicle: Vehicle
 
     # The python lib climate request is also treated as
@@ -93,7 +90,6 @@ class HyundaiKiaCarClimateControlSwitch(HyundaiKiaConnectEntity, ClimateEntity):
             icon="mdi:air-conditioner",
             unit_of_measurement=vehicle._air_temperature_unit,
         )
-        self.vehicle_manager = coordinator.vehicle_manager
         self._attr_unique_id = f"{DOMAIN}_{vehicle.id}_climate_control"
 
         # set the Climate Request to the current actual state of the car
@@ -217,23 +213,12 @@ class HyundaiKiaCarClimateControlSwitch(HyundaiKiaConnectEntity, ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode):
         """Set the operation mode of the in-car climate control."""
 
-        try:
-            if hvac_mode == HVACMode.OFF:
-                await self.hass.async_add_executor_job(
-                    self.vehicle_manager.stop_climate,
-                    self.vehicle.id,
-                )
-            else:
-                await self.hass.async_add_executor_job(
-                    self.vehicle_manager.start_climate,
-                    self.vehicle.id,
-                    self.climate_config,
-                )
-        except UnsupportedControlError as ex:
-            raise HomeAssistantError(
-                f"Climate control not supported by this vehicle: {ex}"
-            ) from ex
-        self.coordinator.async_request_refresh()
+        if hvac_mode == HVACMode.OFF:
+            await self.coordinator.async_stop_climate(self.vehicle.id)
+        else:
+            await self.coordinator.async_start_climate(
+                self.vehicle.id, self.climate_config
+            )
         self.async_write_ha_state()
 
     async def async_set_temperature(self, **kwargs):
@@ -244,23 +229,12 @@ class HyundaiKiaCarClimateControlSwitch(HyundaiKiaConnectEntity, ClimateEntity):
         # activation is controlled separately, but if system is turned on
         # and temp has changed, send update to car
         if self.hvac_mode != HVACMode.OFF and old_temp != self.climate_config.set_temp:
-            try:
-                # Car does not accept changing the temp after starting the heating. So we have to turn off first
-                await self.hass.async_add_executor_job(
-                    self.vehicle_manager.stop_climate,
-                    self.vehicle.id,
-                )
-                # Wait, because the car ignores the start_climate command if it comes too fast after stopping
-                # TODO: replace with some more event driven method
-                await self.hass.async_add_executor_job(sleep, 5.0)
-                await self.hass.async_add_executor_job(
-                    self.vehicle_manager.start_climate,
-                    self.vehicle.id,
-                    self.climate_config,
-                )
-            except UnsupportedControlError as ex:
-                raise HomeAssistantError(
-                    f"Climate control not supported by this vehicle: {ex}"
-                ) from ex
-        self.coordinator.async_request_refresh()
+            # Car does not accept changing the temp after starting the heating. So we have to turn off first
+            await self.coordinator.async_stop_climate(self.vehicle.id)
+            # Wait, because the car ignores the start_climate command if it comes too fast after stopping
+            # TODO: replace with some more event driven method
+            await asyncio.sleep(5)
+            await self.coordinator.async_start_climate(
+                self.vehicle.id, self.climate_config
+            )
         self.async_write_ha_state()


### PR DESCRIPTION
## Summary

The climate entity bypassed the coordinator's action path: `async_set_hvac_mode` / `async_set_temperature` called `vehicle_manager` directly and then invoked `coordinator.async_request_refresh()` **without awaiting it** — the coroutine was created and never executed (`RuntimeWarning: coroutine 'async_request_refresh' was never awaited`, #1798), so entity state only caught up on the next scheduled poll.

The direct calls also skipped the machinery every other action platform gets from `_async_send_action`: the action lock (DuplicateRequestError protection), a token check before sending, action-status confirmation polling (with the device-id retry from Hyundai-Kia-Connect/hyundai_kia_connect_api#1258), and `UnsupportedControlError` → `HomeAssistantError` mapping.

## Changes

- `custom_components/kia_uvo/climate.py`: `async_set_hvac_mode` / `async_set_temperature` now call the coordinator wrappers `async_stop_climate` / `async_start_climate` — the same path as the other action platforms
- the stop → 5 s wait → start sequence for temperature changes is unchanged, only executed via the wrappers (the inline `try/except UnsupportedControlError` moves into `_async_send_action`, which applies the same mapping to every action)
- `async_add_executor_job(sleep, 5.0)` → `await asyncio.sleep(5)` (same delay, doesn't block an executor thread)
- drop the redundant `self.vehicle_manager` attribute; net −26 lines

## Scope

Command path of the climate entity only. No change to read-side properties (hvac_mode, temperatures), entity registration, or other platforms.