### PR TITLE
fix(sensor): always create geocoded location sensor

### DIFF
--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -538,6 +538,17 @@ async def async_setup_entry(
     for vehicle_id in coordinator.vehicle_manager.vehicles:
         vehicle: Vehicle = coordinator.vehicle_manager.vehicles[vehicle_id]
         for description in SENSOR_DESCRIPTIONS:
+            if (
+                description.key == "_geocode_name"
+                and not coordinator.vehicle_manager.geocode_api_enable
+            ):
+                # Created only when the geolocation option is on: without it
+                # the library never runs the geocode lookup, so the sensor
+                # would sit `unknown` forever. With the option on, a None at
+                # setup must not gate creation — see the `_geocode_name`
+                # description above. Gated here, not in `exists`, because the
+                # option is coordinator state.
+                continue
             create = (
                 description.exists(vehicle)
                 if description.exists is not None

--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -281,6 +281,13 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaSensorEntityDescription, ...]] = (
         key="_geocode_name",
         translation_key="geocode_name",
         icon="mdi:map",
+        # The geocoded address is transient — it lives in memory and is None
+        # right after a restart/reload until a poll with coordinates
+        # succeeds. Don't gate creation on it: a None at setup means the
+        # entity isn't yielded and HA marks it "no longer provided", with no
+        # return until the next reload, even after location recovers
+        # (kia_uvo #1844). Always create; None -> HA `unknown`.
+        exists=lambda _: True,
     ),
     HyundaiKiaSensorEntityDescription(
         key="dtc_count",


### PR DESCRIPTION
## Summary

The geocoded-location sensor is created at setup only when a geocode is already known (`sensor.py` creation gate: `getattr(vehicle, key, None) is not None`). The geocode lives in memory next to the vehicle coordinates: after a Home Assistant restart or integration reload it is `None` until a poll fetches coordinates and the geocode lookup succeeds.

While it is `None` at setup, the entity isn't yielded, and HA marks it **"no longer provided"** — it shows unavailable and never returns until the next reload, even after location recovers on a later poll. Combined with a flaky Find-My-Car response this is kia_uvo #1844: *"gone for weeks and then came back"* — it came back on a restart, not when the car moved.

## Changes

- `custom_components/kia_uvo/sensor.py`: always create the `_geocode_name` sensor. A `None` value renders as HA `unknown` and the real value arrives on the first successful geocode, without requiring a reload.

## Scope

- Same pattern as the 12V SoC sensor (#1803): transient value → don't gate creation on it.
- The device_tracker already creates unconditionally and turns available on the first poll with coordinates — no change needed there.
- The location-recovery itself (fetch after restart when the car is parked) is handled on the library side by Hyundai-Kia-Connect/hyundai_kia_connect_api#1294; this PR covers the entity that would otherwise stay stale-unavailable even after recovery.

Fixes Hyundai-Kia-Connect/kia_uvo#1844
