### PR TITLE
refactor: mypy --strict for core integration files + CI job

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,3 +20,25 @@ jobs:
         uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa # main
         with:
           category: integration
+
+  validate-mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13"
+      - name: Install mypy and dependencies
+        run: |
+          pip install mypy==2.3.1 homeassistant==2026.2.3 hyundai_kia_connect_api==4.27.2
+      - name: Run mypy
+        # Phase 1: core non-platform files. Extend to the whole
+        # custom_components/kia_uvo/ package once the platform files are
+        # strict-clean as well.
+        run: |
+          mypy --strict --ignore-missing-imports \
+            custom_components/kia_uvo/__init__.py \
+            custom_components/kia_uvo/config_flow.py \
+            custom_components/kia_uvo/coordinator.py \
+            custom_components/kia_uvo/entity.py \
+            custom_components/kia_uvo/services.py

--- a/custom_components/kia_uvo/__init__.py
+++ b/custom_components/kia_uvo/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntry
 
 from .const import (
@@ -45,7 +46,7 @@ PLATFORMS: list[str] = [
 ]
 
 
-async def async_setup(hass: HomeAssistant, config_entry: ConfigEntry):
+async def async_setup(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     return True
 
 
@@ -77,7 +78,7 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     return unload_ok
 
 
-async def async_migrate_entry(hass, config_entry: ConfigEntry):
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     if config_entry.version == 1:
         _LOGGER.debug(f"{DOMAIN} - config data- {config_entry}")
         username = config_entry.data.get(CONF_USERNAME)
@@ -112,10 +113,8 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
             CONF_FORCE_REFRESH_INTERVAL: force_refresh_interval,
             CONF_SCAN_INTERVAL: scan_interval,
         }
-        registry = hass.helpers.entity_registry.async_get(hass)
-        entities = hass.helpers.entity_registry.async_entries_for_config_entry(
-            registry, config_entry.entry_id
-        )
+        registry = er.async_get(hass)
+        entities = er.async_entries_for_config_entry(registry, config_entry.entry_id)
         for entity in entities:
             registry.async_remove(entity.entity_id)
 

--- a/custom_components/kia_uvo/config_flow.py
+++ b/custom_components/kia_uvo/config_flow.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
 from homeassistant.const import (
     CONF_PASSWORD,
     CONF_PIN,
@@ -17,7 +17,6 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.selector import selector
 from hyundai_kia_connect_api import Token, VehicleManager
@@ -134,7 +133,7 @@ OPTIONS_SCHEMA = vol.Schema(
 async def validate_input(
     hass: HomeAssistant,
     user_input: dict[str, Any],
-    vehicle_manager: VehicleManager | None = None,
+    vehicle_manager: VehicleManager,
 ) -> Token | OTPRequest:
     """Validate the user input allows us to connect."""
     try:
@@ -153,7 +152,7 @@ class HyundaiKiaConnectOptionFlowHandler(config_entries.OptionsFlowWithReload):
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle options init setup."""
 
         if user_input is not None:
@@ -175,23 +174,25 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 2
     reauth_entry: ConfigEntry | None = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the config flow."""
-        self._region_data = None
+        self._region_data: dict[str, Any] | None = None
         self._vehicle_manager: VehicleManager | None = None
-        self._pending_login_data = None
+        self._pending_login_data: dict[str, Any] | None = None
         self._otp_request: OTPRequest | None = None
         self._is_reconfigure = False
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry: ConfigEntry):
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> HyundaiKiaConnectOptionFlowHandler:
         """Initiate options flow instance."""
         return HyundaiKiaConnectOptionFlowHandler()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle the initial step for region/brand selection."""
         if user_input is None:
             return self.async_show_form(
@@ -211,11 +212,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_credentials_password(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle the credentials step."""
         errors = {}
 
         if user_input is not None:
+            assert self._region_data is not None
             # Combine region data with credentials
             full_config = {**self._region_data, **user_input}
             self._vehicle_manager = VehicleManager(
@@ -268,14 +270,18 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_step_select_otp_method(self, user_input=None):
+    async def async_step_select_otp_method(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Let user choose email or SMS."""
         if user_input is None:
             # Add code to build a list of available OTP methods
+            otp_request = self._otp_request
+            assert otp_request is not None
             otp_methods = []
-            if self._otp_request.has_email:
+            if otp_request.has_email:
                 otp_methods.append("EMAIL")
-            if self._otp_request.has_sms:
+            if otp_request.has_sms:
                 otp_methods.append("SMS")
             return self.async_show_form(
                 step_id="select_otp_method",
@@ -285,11 +291,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             method = OTP_NOTIFY_TYPE.EMAIL
         if user_input["method"] == "SMS":
             method = OTP_NOTIFY_TYPE.SMS
-        await self.hass.async_add_executor_job(self._vehicle_manager.send_otp, method)
+        vehicle_manager = self._vehicle_manager
+        assert vehicle_manager is not None
+        await self.hass.async_add_executor_job(vehicle_manager.send_otp, method)
 
         return await self.async_step_enter_otp()
 
-    async def async_step_enter_otp(self, user_input=None):
+    async def async_step_enter_otp(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Prompt user to enter the OTP."""
         errors = {}
 
@@ -298,9 +308,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 step_id="enter_otp", data_schema=vol.Schema({vol.Required("otp"): str})
             )
 
+        vehicle_manager = self._vehicle_manager
+        assert vehicle_manager is not None
         try:
             await self.hass.async_add_executor_job(
-                self._vehicle_manager.verify_otp_and_complete_login,
+                vehicle_manager.verify_otp_and_complete_login,
                 user_input["otp"],
             )
         except AuthenticationError:
@@ -310,34 +322,37 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 data_schema=vol.Schema({vol.Required("otp"): str}),
                 errors=errors,
             )
-        self._pending_login_data[CONF_TOKEN] = self._vehicle_manager.token.to_dict()
+        pending_login_data = self._pending_login_data
+        assert pending_login_data is not None
+        pending_login_data[CONF_TOKEN] = vehicle_manager.token.to_dict()
         if self._is_reconfigure:
             return self.async_update_reload_and_abort(
                 self._get_reconfigure_entry(),
-                data_updates=self._pending_login_data,
+                data_updates=pending_login_data,
             )
         elif self.reauth_entry is None:
-            title = f"{BRANDS[self._pending_login_data[CONF_BRAND]]} {REGIONS[self._pending_login_data[CONF_REGION]]} {self._pending_login_data[CONF_USERNAME]}"
+            title = f"{BRANDS[pending_login_data[CONF_BRAND]]} {REGIONS[pending_login_data[CONF_REGION]]} {pending_login_data[CONF_USERNAME]}"
             await self.async_set_unique_id(
                 hashlib.sha256(title.encode("utf-8")).hexdigest()
             )
             self._abort_if_unique_id_configured()
 
-            return self.async_create_entry(title=title, data=self._pending_login_data)
+            return self.async_create_entry(title=title, data=pending_login_data)
         else:
             self.hass.config_entries.async_update_entry(
-                self.reauth_entry, data=self._pending_login_data
+                self.reauth_entry, data=pending_login_data
             )
             await self.hass.config_entries.async_reload(self.reauth_entry.entry_id)
             return self.async_abort(reason="reauth_successful")
 
     async def async_step_credentials_token(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle the credentials step."""
         errors = {}
 
         if user_input is not None:
+            assert self._region_data is not None
             # Combine region data with credentials
             full_config = {**self._region_data, **user_input}
             self._vehicle_manager = VehicleManager(
@@ -385,7 +400,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Present choice: re-authenticate or set/change PIN."""
         if user_input is not None:
             if user_input["reconfigure_choice"] == "reauth":
@@ -401,7 +416,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_reconfigure_pin(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Allow the user to set or change the PIN without full re-authentication."""
         if user_input is not None:
             new_pin = user_input[CONF_PIN]
@@ -421,14 +436,18 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=STEP_PIN_ONLY_SCHEMA,
         )
 
-    async def async_step_reauth(self, user_input=None):
+    async def async_step_reauth(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Perform reauth upon an API authentication error."""
         self.reauth_entry = self.hass.config_entries.async_get_entry(
             self.context["entry_id"]
         )
         return await self.async_step_reauth_confirm()
 
-    async def async_step_reauth_confirm(self, user_input=None):
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
         """Dialog that informs the user that reauth is required."""
         if user_input is None:
             return self.async_show_form(

--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -58,7 +58,7 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
+class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Class to manage fetching data from the API."""
 
     def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
@@ -125,7 +125,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
             self.no_force_refresh_hour_finish,
         )
 
-    async def _async_update_data(self):
+    async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library. Called by update_coordinator periodically.
 
         Allow to update for the first time without further checking
@@ -221,14 +221,16 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
         )
         self.async_set_updated_data(self.data)
 
-    async def async_check_and_refresh_token(self):
+    async def async_check_and_refresh_token(self) -> None:
         """Refresh token if needed via library."""
         await self.hass.async_add_executor_job(
             self.vehicle_manager.check_and_refresh_token
         )
         await self._async_save_token()
 
-    async def async_await_action_and_refresh(self, vehicle_id, action_id):
+    async def async_await_action_and_refresh(
+        self, vehicle_id: str, action_id: str
+    ) -> None:
         try:
             await asyncio.sleep(5)
             await self.hass.async_add_executor_job(
@@ -241,7 +243,9 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
         finally:
             await self.async_refresh()
 
-    async def async_await_action_and_force_refresh(self, vehicle_id, action_id):
+    async def async_await_action_and_force_refresh(
+        self, vehicle_id: str, action_id: str
+    ) -> None:
         """Wait for action then force refresh to get fresh vehicle data.
 
         Used after setting charge limits because the soft refresh (cmm/gvi)
@@ -278,7 +282,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
         error_label: str,
         *,
         force_refresh: bool = False,
-    ):
+    ) -> None:
         """Send a vehicle action, wait for completion, and refresh data.
 
         Serializes actions with a lock to prevent DuplicateRequestError
@@ -318,76 +322,76 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
                     error_label,
                 )
 
-    async def async_lock_vehicle(self, vehicle_id: str):
+    async def async_lock_vehicle(self, vehicle_id: str) -> None:
         await self._async_send_action(
             vehicle_id,
             lambda: self.vehicle_manager.lock(vehicle_id),
             "lock vehicle",
         )
 
-    async def async_unlock_vehicle(self, vehicle_id: str):
+    async def async_unlock_vehicle(self, vehicle_id: str) -> None:
         await self._async_send_action(
             vehicle_id,
             lambda: self.vehicle_manager.unlock(vehicle_id),
             "unlock vehicle",
         )
 
-    async def async_open_charge_port(self, vehicle_id: str):
+    async def async_open_charge_port(self, vehicle_id: str) -> None:
         await self._async_send_action(
             vehicle_id,
             lambda: self.vehicle_manager.open_charge_port(vehicle_id),
             "open charge port",
         )
 
-    async def async_close_charge_port(self, vehicle_id: str):
+    async def async_close_charge_port(self, vehicle_id: str) -> None:
         await self._async_send_action(
             vehicle_id,
             lambda: self.vehicle_manager.close_charge_port(vehicle_id),
             "close charge port",
         )
 
-    async def async_start_climate_default(self, vehicle_id: str):
+    async def async_start_climate_default(self, vehicle_id: str) -> None:
         """Start climate with default options (API fills sensible defaults)."""
         await self.async_start_climate(vehicle_id, ClimateRequestOptions())
 
     async def async_start_climate(
         self, vehicle_id: str, climate_options: ClimateRequestOptions
-    ):
+    ) -> None:
         await self._async_send_action(
             vehicle_id,
             lambda: self.vehicle_manager.start_climate(vehicle_id, climate_options),
             "start climate",
         )
 
-    async def async_stop_climate(self, vehicle_id: str):
+    async def async_stop_climate(self, vehicle_id: str) -> None:
         await self._async_send_action(
             vehicle_id,
             lambda: self.vehicle_manager.stop_climate(vehicle_id),
             "stop climate",
         )
 
-    async def async_start_charge(self, vehicle_id: str):
+    async def async_start_charge(self, vehicle_id: str) -> None:
         await self._async_send_action(
             vehicle_id,
             lambda: self.vehicle_manager.start_charge(vehicle_id),
             "start charge",
         )
 
-    async def async_stop_charge(self, vehicle_id: str):
+    async def async_stop_charge(self, vehicle_id: str) -> None:
         await self._async_send_action(
             vehicle_id,
             lambda: self.vehicle_manager.stop_charge(vehicle_id),
             "stop charge",
         )
 
-    async def async_set_charge_limits(self, vehicle_id: str, ac: int, dc: int):
+    async def async_set_charge_limits(self, vehicle_id: str, ac: int, dc: int) -> None:
         await self._async_send_action(
             vehicle_id,
             lambda: self.vehicle_manager.set_charge_limits(vehicle_id, ac, dc),
             "set charge limits",
         )
 
-    async def async_set_charging_current(self, vehicle_id: str, level: int):
+    async def async_set_charging_current(self, vehicle_id: str, level: int) -> None:
         await self._async_send_action(
             vehicle_id,
             lambda: self.vehicle_manager.set_charging_current(vehicle_id, level),
@@ -396,7 +400,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def async_schedule_charging_and_climate(
         self, vehicle_id: str, schedule_options: ScheduleChargingClimateRequestOptions
-    ):
+    ) -> None:
         await self._async_send_action(
             vehicle_id,
             lambda: self.vehicle_manager.schedule_charging_and_climate(
@@ -431,7 +435,9 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
             defrost=vehicle.ev_first_departure_climate_defrost or False,
         )
 
-    async def async_set_schedule_charge_enabled(self, vehicle_id: str, enabled: bool):
+    async def async_set_schedule_charge_enabled(
+        self, vehicle_id: str, enabled: bool
+    ) -> None:
         """Toggle scheduled charging on/off."""
         vehicle = self.vehicle_manager.vehicles[vehicle_id]
         options = self._build_schedule_options_from_vehicle(vehicle)
@@ -440,7 +446,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def async_set_off_peak_charge_only_enabled(
         self, vehicle_id: str, enabled: bool
-    ):
+    ) -> None:
         """Toggle off-peak charge only on/off."""
         vehicle = self.vehicle_manager.vehicles[vehicle_id]
         options = self._build_schedule_options_from_vehicle(vehicle)
@@ -484,7 +490,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def async_set_departure_enabled(
         self, vehicle_id: str, departure_num: int, enabled: bool
-    ):
+    ) -> None:
         """Toggle a departure schedule on/off."""
         vehicle = self.vehicle_manager.vehicles[vehicle_id]
         options = self._build_schedule_options_from_vehicle(vehicle)
@@ -502,7 +508,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def async_set_departure_climate_enabled(
         self, vehicle_id: str, departure_num: int, enabled: bool
-    ):
+    ) -> None:
         """Toggle departure climate on/off."""
         vehicle = self.vehicle_manager.vehicles[vehicle_id]
         options = self._build_schedule_options_from_vehicle(vehicle)
@@ -511,42 +517,42 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def async_set_departure_defrost(
         self, vehicle_id: str, departure_num: int, enabled: bool
-    ):
+    ) -> None:
         """Toggle departure defrost on/off."""
         vehicle = self.vehicle_manager.vehicles[vehicle_id]
         options = self._build_schedule_options_from_vehicle(vehicle)
         options.defrost = enabled
         await self.async_schedule_charging_and_climate(vehicle_id, options)
 
-    async def async_start_hazard_lights(self, vehicle_id: str):
+    async def async_start_hazard_lights(self, vehicle_id: str) -> None:
         await self._async_send_action(
             vehicle_id,
             lambda: self.vehicle_manager.start_hazard_lights(vehicle_id),
             "start hazard lights",
         )
 
-    async def async_start_hazard_lights_and_horn(self, vehicle_id: str):
+    async def async_start_hazard_lights_and_horn(self, vehicle_id: str) -> None:
         await self._async_send_action(
             vehicle_id,
             lambda: self.vehicle_manager.start_hazard_lights_and_horn(vehicle_id),
             "start hazard lights and horn",
         )
 
-    async def async_start_valet_mode(self, vehicle_id: str):
+    async def async_start_valet_mode(self, vehicle_id: str) -> None:
         await self._async_send_action(
             vehicle_id,
             lambda: self.vehicle_manager.start_valet_mode(vehicle_id),
             "start valet mode",
         )
 
-    async def async_stop_valet_mode(self, vehicle_id: str):
+    async def async_stop_valet_mode(self, vehicle_id: str) -> None:
         await self._async_send_action(
             vehicle_id,
             lambda: self.vehicle_manager.stop_valet_mode(vehicle_id),
             "stop valet mode",
         )
 
-    async def async_set_v2l_limit(self, vehicle_id: str, limit: int):
+    async def async_set_v2l_limit(self, vehicle_id: str, limit: int) -> None:
         await self._async_send_action(
             vehicle_id,
             lambda: self.vehicle_manager.set_vehicle_to_load_discharge_limit(
@@ -557,21 +563,23 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def async_set_windows(
         self, vehicle_id: str, windowOptions: WindowRequestOptions
-    ):
+    ) -> None:
         await self._async_send_action(
             vehicle_id,
             lambda: self.vehicle_manager.set_windows_state(vehicle_id, windowOptions),
             "set windows",
         )
 
-    async def async_set_navigation(self, vehicle_id: str, poi_list: list[POIInfo]):
+    async def async_set_navigation(
+        self, vehicle_id: str, poi_list: list[POIInfo]
+    ) -> None:
         await self._async_send_action(
             vehicle_id,
             lambda: self.vehicle_manager.set_navigation(vehicle_id, poi_list),
             "set navigation",
         )
 
-    async def async_open_all_windows(self, vehicle_id: str):
+    async def async_open_all_windows(self, vehicle_id: str) -> None:
         options = WindowRequestOptions(
             front_left=WINDOW_STATE.OPEN,
             front_right=WINDOW_STATE.OPEN,
@@ -584,7 +592,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
             "open all windows",
         )
 
-    async def async_close_all_windows(self, vehicle_id: str):
+    async def async_close_all_windows(self, vehicle_id: str) -> None:
         options = WindowRequestOptions(
             front_left=WINDOW_STATE.CLOSED,
             front_right=WINDOW_STATE.CLOSED,
@@ -597,7 +605,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
             "close all windows",
         )
 
-    async def async_vent_all_windows(self, vehicle_id: str):
+    async def async_vent_all_windows(self, vehicle_id: str) -> None:
         options = WindowRequestOptions(
             front_left=WINDOW_STATE.VENTILATION,
             front_right=WINDOW_STATE.VENTILATION,
@@ -610,12 +618,12 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator):
             "vent all windows",
         )
 
-    async def _async_save_token(self):
+    async def _async_save_token(self) -> None:
         """Persist the latest token into the config entry."""
+        config_entry = self.config_entry
+        assert config_entry is not None
         new_token = self.vehicle_manager.token.to_dict()
         # Only update if token actually changed
-        if new_token and new_token != self.config_entry.data.get(CONF_TOKEN):
-            updated_data = {**self.config_entry.data, CONF_TOKEN: new_token}
-            self.hass.config_entries.async_update_entry(
-                self.config_entry, data=updated_data
-            )
+        if new_token and new_token != config_entry.data.get(CONF_TOKEN):
+            updated_data = {**config_entry.data, CONF_TOKEN: new_token}
+            self.hass.config_entries.async_update_entry(config_entry, data=updated_data)

--- a/custom_components/kia_uvo/entity.py
+++ b/custom_components/kia_uvo/entity.py
@@ -1,23 +1,31 @@
 """Base Entity for Hyundai / Kia Connect integration."""
 
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from hyundai_kia_connect_api import Vehicle
 
 from .const import BRANDS, DOMAIN, REGIONS
+from .coordinator import HyundaiKiaConnectDataUpdateCoordinator
 
 
-class HyundaiKiaConnectEntity(CoordinatorEntity):
+class HyundaiKiaConnectEntity(
+    CoordinatorEntity[HyundaiKiaConnectDataUpdateCoordinator]
+):
     """Class for base entity for Hyundai / Kia Connect integration."""
 
     _attr_has_entity_name = True
 
-    def __init__(self, coordinator, vehicle):
+    def __init__(
+        self,
+        coordinator: HyundaiKiaConnectDataUpdateCoordinator,
+        vehicle: Vehicle,
+    ) -> None:
         """Initialize the base entity."""
         super().__init__(coordinator)
         self.vehicle = vehicle
 
     @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo:
         """Return device information to use for this entity."""
         return DeviceInfo(
             identifiers={(DOMAIN, self.vehicle.id)},

--- a/custom_components/kia_uvo/services.py
+++ b/custom_components/kia_uvo/services.py
@@ -1,10 +1,11 @@
 import logging
 from datetime import datetime
-from typing import cast
+from typing import Any, cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_DEVICE_ID
 from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry
 from hyundai_kia_connect_api import (
     ClimateRequestOptions,
@@ -68,16 +69,16 @@ _LOGGER = logging.getLogger(__name__)
 def async_setup_services(hass: HomeAssistant) -> bool:
     """Set up services for Hyundai Kia Connect"""
 
-    async def async_handle_force_update(call):
+    async def async_handle_force_update(call: ServiceCall) -> None:
         coordinator = _get_coordinator_from_device(hass, call)
         await coordinator.async_force_update_all()
 
-    async def async_handle_update(call):
+    async def async_handle_update(call: ServiceCall) -> None:
         _LOGGER.debug(f"Call:{call.data}")
         coordinator = _get_coordinator_from_device(hass, call)
         await coordinator.async_update_all()
 
-    async def async_handle_start_climate(call):
+    async def async_handle_start_climate(call: ServiceCall) -> None:
         coordinator = _get_coordinator_from_device(hass, call)
         vehicle_id = _get_vehicle_id_from_device(hass, call)
         duration = call.data.get("duration")
@@ -119,42 +120,42 @@ def async_setup_services(hass: HomeAssistant) -> bool:
         )
         await coordinator.async_start_climate(vehicle_id, climate_request_options)
 
-    async def async_handle_stop_climate(call):
+    async def async_handle_stop_climate(call: ServiceCall) -> None:
         coordinator = _get_coordinator_from_device(hass, call)
         vehicle_id = _get_vehicle_id_from_device(hass, call)
         await coordinator.async_stop_climate(vehicle_id)
 
-    async def async_handle_lock(call):
+    async def async_handle_lock(call: ServiceCall) -> None:
         coordinator = _get_coordinator_from_device(hass, call)
         vehicle_id = _get_vehicle_id_from_device(hass, call)
         await coordinator.async_lock_vehicle(vehicle_id)
 
-    async def async_handle_unlock(call):
+    async def async_handle_unlock(call: ServiceCall) -> None:
         coordinator = _get_coordinator_from_device(hass, call)
         vehicle_id = _get_vehicle_id_from_device(hass, call)
         await coordinator.async_unlock_vehicle(vehicle_id)
 
-    async def async_handle_open_charge_port(call):
+    async def async_handle_open_charge_port(call: ServiceCall) -> None:
         coordinator = _get_coordinator_from_device(hass, call)
         vehicle_id = _get_vehicle_id_from_device(hass, call)
         await coordinator.async_open_charge_port(vehicle_id)
 
-    async def async_handle_close_charge_port(call):
+    async def async_handle_close_charge_port(call: ServiceCall) -> None:
         coordinator = _get_coordinator_from_device(hass, call)
         vehicle_id = _get_vehicle_id_from_device(hass, call)
         await coordinator.async_close_charge_port(vehicle_id)
 
-    async def async_handle_start_charge(call):
+    async def async_handle_start_charge(call: ServiceCall) -> None:
         coordinator = _get_coordinator_from_device(hass, call)
         vehicle_id = _get_vehicle_id_from_device(hass, call)
         await coordinator.async_start_charge(vehicle_id)
 
-    async def async_handle_stop_charge(call):
+    async def async_handle_stop_charge(call: ServiceCall) -> None:
         coordinator = _get_coordinator_from_device(hass, call)
         vehicle_id = _get_vehicle_id_from_device(hass, call)
         await coordinator.async_stop_charge(vehicle_id)
 
-    async def async_handle_set_charge_limit(call):
+    async def async_handle_set_charge_limit(call: ServiceCall) -> None:
         coordinator = _get_coordinator_from_device(hass, call)
         vehicle_id = _get_vehicle_id_from_device(hass, call)
         ac = call.data.get("ac_limit")
@@ -167,7 +168,7 @@ def async_setup_services(hass: HomeAssistant) -> bool:
                 f"{DOMAIN} - Enable to set charge limits.  Both AC and DC value required, but not provided."
             )
 
-    async def async_handle_set_windows(call):
+    async def async_handle_set_windows(call: ServiceCall) -> None:
         coordinator = _get_coordinator_from_device(hass, call)
         vehicle_id = _get_vehicle_id_from_device(hass, call)
         window_options = WindowRequestOptions(
@@ -187,7 +188,7 @@ def async_setup_services(hass: HomeAssistant) -> bool:
         else:
             _LOGGER.error(f"{DOMAIN} -  All windows value required, but not provided.")
 
-    async def async_handle_set_charging_current(call):
+    async def async_handle_set_charging_current(call: ServiceCall) -> None:
         coordinator = _get_coordinator_from_device(hass, call)
         vehicle_id = _get_vehicle_id_from_device(hass, call)
         current_level = call.data.get("level")
@@ -199,7 +200,7 @@ def async_setup_services(hass: HomeAssistant) -> bool:
                 f"{DOMAIN} - Enable to set charging current.  Level required, but not provided."
             )
 
-    async def async_handle_schedule_charging_and_climate(call):
+    async def async_handle_schedule_charging_and_climate(call: ServiceCall) -> None:
         coordinator = _get_coordinator_from_device(hass, call)
         vehicle_id = _get_vehicle_id_from_device(hass, call)
         first_departure_enabled = call.data.get("first_departure_enabled")
@@ -219,8 +220,8 @@ def async_setup_services(hass: HomeAssistant) -> bool:
 
         # Confirm values are correct datatype
         def initialize_departure_option(
-            departure_enabled, departure_days, departure_time
-        ):
+            departure_enabled: Any, departure_days: Any, departure_time: Any
+        ) -> ScheduleChargingClimateRequestOptions.DepartureOptions:
             return ScheduleChargingClimateRequestOptions.DepartureOptions(
                 enabled=None if departure_enabled is None else bool(departure_enabled),
                 days=None
@@ -272,7 +273,7 @@ def async_setup_services(hass: HomeAssistant) -> bool:
             vehicle_id, schedule_options
         )
 
-    async def async_handle_set_off_peak_charging(call):
+    async def async_handle_set_off_peak_charging(call: ServiceCall) -> None:
         coordinator = _get_coordinator_from_device(hass, call)
         vehicle_id = _get_vehicle_id_from_device(hass, call)
         mode = call.data.get("mode")
@@ -291,27 +292,27 @@ def async_setup_services(hass: HomeAssistant) -> bool:
             end=off_peak_end_time,
         )
 
-    async def async_handle_start_hazard_lights(call):
+    async def async_handle_start_hazard_lights(call: ServiceCall) -> None:
         coordinator = _get_coordinator_from_device(hass, call)
         vehicle_id = _get_vehicle_id_from_device(hass, call)
         await coordinator.async_start_hazard_lights(vehicle_id)
 
-    async def async_handle_start_hazard_lights_and_horn(call):
+    async def async_handle_start_hazard_lights_and_horn(call: ServiceCall) -> None:
         coordinator = _get_coordinator_from_device(hass, call)
         vehicle_id = _get_vehicle_id_from_device(hass, call)
         await coordinator.async_start_hazard_lights_and_horn(vehicle_id)
 
-    async def async_handle_start_valet_mode(call):
+    async def async_handle_start_valet_mode(call: ServiceCall) -> None:
         coordinator = _get_coordinator_from_device(hass, call)
         vehicle_id = _get_vehicle_id_from_device(hass, call)
         await coordinator.async_start_valet_mode(vehicle_id)
 
-    async def async_handle_stop_valet_mode(call):
+    async def async_handle_stop_valet_mode(call: ServiceCall) -> None:
         coordinator = _get_coordinator_from_device(hass, call)
         vehicle_id = _get_vehicle_id_from_device(hass, call)
         await coordinator.async_stop_valet_mode(vehicle_id)
 
-    async def async_handle_set_navigation(call):
+    async def async_handle_set_navigation(call: ServiceCall) -> None:
         coordinator = _get_coordinator_from_device(hass, call)
         vehicle_id = _get_vehicle_id_from_device(hass, call)
         latitude = call.data["latitude"]
@@ -359,7 +360,7 @@ def async_setup_services(hass: HomeAssistant) -> bool:
 
 
 @callback
-def async_unload_services(hass) -> None:
+def async_unload_services(hass: HomeAssistant) -> None:
     for service in SUPPORTED_SERVICES:
         hass.services.async_remove(DOMAIN, service)
 
@@ -367,12 +368,16 @@ def async_unload_services(hass) -> None:
 def _get_vehicle_id_from_device(hass: HomeAssistant, call: ServiceCall) -> str:
     coordinators = list(hass.data[DOMAIN].keys())
     if len(coordinators) == 1:
-        coordinator = hass.data[DOMAIN][coordinators[0]]
+        coordinator = cast(
+            HyundaiKiaConnectDataUpdateCoordinator, hass.data[DOMAIN][coordinators[0]]
+        )
         vehicles = coordinator.vehicle_manager.vehicles
         if len(vehicles) == 1:
-            return next(iter(vehicles.keys()))
+            return cast(str, next(iter(vehicles.keys())))
 
     device_entry = device_registry.async_get(hass).async_get(call.data[ATTR_DEVICE_ID])
+    if device_entry is None:
+        raise HomeAssistantError(f"Device {call.data[ATTR_DEVICE_ID]} not found")
     for entry in device_entry.identifiers:
         if entry[0] == DOMAIN:
             vehicle_id = entry[1]
@@ -384,11 +389,15 @@ def _get_coordinator_from_device(
 ) -> HyundaiKiaConnectDataUpdateCoordinator:
     coordinators = list(hass.data[DOMAIN].keys())
     if len(coordinators) == 1:
-        return hass.data[DOMAIN][coordinators[0]]
+        return cast(
+            HyundaiKiaConnectDataUpdateCoordinator, hass.data[DOMAIN][coordinators[0]]
+        )
     else:
         device_entry = device_registry.async_get(hass).async_get(
             call.data[ATTR_DEVICE_ID]
         )
+        if device_entry is None:
+            raise HomeAssistantError(f"Device {call.data[ATTR_DEVICE_ID]} not found")
         config_entry_ids = device_entry.config_entries
         config_entry_id = next(
             (
@@ -402,7 +411,15 @@ def _get_coordinator_from_device(
             ),
             None,
         )
-        config_entry_unique_id = hass.config_entries.async_get_entry(
-            config_entry_id
-        ).unique_id
-        return hass.data[DOMAIN][config_entry_unique_id]
+        if config_entry_id is None:
+            raise HomeAssistantError(
+                f"No {DOMAIN} config entry found for device {call.data[ATTR_DEVICE_ID]}"
+            )
+        config_entry = hass.config_entries.async_get_entry(config_entry_id)
+        if config_entry is None:
+            raise HomeAssistantError(f"Config entry {config_entry_id} not found")
+        config_entry_unique_id = config_entry.unique_id
+        return cast(
+            HyundaiKiaConnectDataUpdateCoordinator,
+            hass.data[DOMAIN][config_entry_unique_id],
+        )


### PR DESCRIPTION
## Summary

- Annotate the five core non-platform files (`__init__`, `config_flow`, `coordinator`, `entity`, `services`) so they pass `mypy --strict --ignore-missing-imports` with `homeassistant` resolvable: **122 errors → 0**.
- Add a `validate-mypy` job to the Validate workflow with a pinned toolchain: mypy 2.3.1, homeassistant 2026.2.3, hyundai_kia_connect_api 4.27.2 (matching `manifest.json`).

## Why a workflow job instead of the pre-commit mypy hook

The existing mypy pre-commit hook only matches root-level `.py` files, so `custom_components/` is currently never checked. Enabling checking there requires `homeassistant` in the hook env — without it mypy emits 12 errors on these files (untyped `@callback` decorator, `Any` returns), so widening `files:` alone would make CI red. Adding `homeassistant` to the hook's `additional_dependencies` makes the env build depend on the interpreter pre-commit.ci provides (undocumented; homeassistant ≥ 2026.x requires Python ≥ 3.13) — a failed env build would break CI for every PR. A workflow job with `setup-python` pinned to 3.13 is deterministic. This mirrors HA core, which also keeps mypy out of the pre-commit hook env.

## Notable typing details

- `config_flow.py`: `FlowResult` → `ConfigFlowResult` (canonical since HA 2024.4); typed flow state attributes; assert-narrowing of flow step invariants (`_region_data`, `_otp_request`, `_pending_login_data`, `_vehicle_manager`).
- `entity.py`: parametrized `CoordinatorEntity[HyundaiKiaConnectDataUpdateCoordinator]` — this also removes the `attr-defined` errors on platform entities (follow-up PR).
- `services.py`: device/config-entry `None` guards now raise `HomeAssistantError` with an explicit message instead of crashing with `AttributeError`; deprecated `hass.helpers.entity_registry` replaced by `er.async_get`.
- `validate_input`'s `vehicle_manager` parameter became required — both call sites always passed it, and the old `= None` default would call `None.login`.

## Scope

Only core files — no file overlap with open PRs #1847, #1856, #1745. Platform files (99 remaining errors, incl. two `@dataclass(frozen=True, slots=True)` conversions) follow in a phase-2 PR once those merge.

Observation (untouched, out of scope): `config_flow.py` sets `self._reauth_config = True` in `async_step_reauth_confirm`, but nothing reads that attribute.

## Verification

- `mypy --strict --ignore-missing-imports` (pins as in CI): 0 errors on the 5 files.
- ruff 0.16.4 check + format: clean on all tracked `.py`.
- pytest: 62 passed.
- yamllint / prettier clean on `validate.yml`; hassfest-neutral (no manifest/strings/services changes).
