### PR TITLE
fix(bump): sanitize closes tails in bump PR body

### DIFF
--- a/scripts/bump_api_dependency.py
+++ b/scripts/bump_api_dependency.py
@@ -8,11 +8,13 @@ import re
 import sys
 import urllib.error
 import urllib.request
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 API_OWNER = "Hyundai-Kia-Connect"
 API_REPO = "hyundai_kia_connect_api"
+KIA_UVO_REPO = "kia_uvo"
 BRANCH_NAME = "chore/bump-api-dependency"
 PACKAGE_NAME = "hyundai_kia_connect_api"
 
@@ -119,33 +121,151 @@ def _normalize_issue_refs(body: str, owner: str, repo: str) -> str:
     return re.sub(r"#(\d+)", _replace_plain, body)
 
 
+_SHORT_REPO_REF_RE = re.compile(r"(?<![\w./-])(hyundai_kia_connect_api|kia_uvo)#(\d+)")
+
+
+def _qualify_short_repo_refs(body: str) -> str:
+    """Qualify bare shortname refs (``kia_uvo#1823``) to ``owner/repo#N`` form.
+
+    ``shortname#N`` in a PR body renders as ``github.com/<shortname>/issues/N``
+    — a repo that does not exist — and semantic-release copies it verbatim into
+    release notes. Only refs not already owner-qualified are rewritten; the
+    lookbehind skips the ``.../kia_uvo#N`` inside full ``owner/repo#N`` refs.
+    """
+    return _SHORT_REPO_REF_RE.sub(
+        lambda m: f"{API_OWNER}/{m.group(1)}#{m.group(2)}", body
+    )
+
+
 _CLOSES_TAIL_RE = re.compile(r"(.*?\bcloses\s+)(.+)$", re.IGNORECASE)
+_GITHUB_REF_URL_RE = re.compile(r"github\.com/[\w.-]+/([\w.-]+)/(?:issues|pull)/(\d+)")
+_REF_TEXT_RE = re.compile(r"^(?:[\w.-]+/)?([\w.-]+)#(\d+)$")
 
 
-def _dedup_closes_refs(line: str) -> str:
-    """Collapse duplicate refs in a release-note line's ``closes ...`` tail.
+def _kia_uvo_ref(num: str) -> str:
+    """Canonical markdown form of a kia_uvo issue reference."""
+    return (
+        f"[{API_OWNER}/{KIA_UVO_REPO}#{num}]"
+        f"(https://github.com/{API_OWNER}/{KIA_UVO_REPO}/issues/{num})"
+    )
 
-    Upstream API release notes (semantic-release) sometimes emit the same
-    ticket twice in the ``closes`` footer of a fix/feat line. The dedup key is
-    the ref's text without its URL parens (e.g.
-    ``Hyundai-Kia-Connect/hyundai_kia_connect_api#1195``), not the bare number,
-    so ``api#1447`` and ``kia_uvo#1447`` stay distinct while a repeated
-    ``api#1195`` collapses to its first occurrence (first URL kept, order kept).
+
+def _ref_target(token: str) -> tuple[str, str] | None:
+    """Return (repo, issue number) for one closes-tail token, else None.
+
+    The repo comes from the token's github URL when it has one, else from its
+    text (``owner/repo#N`` / ``shortname#N``). A bare ``#N`` reads in API-repo
+    context, since upstream release notes are written there.
+    """
+    m = re.fullmatch(r"\[([^\]]+)\]\(([^)]*)\)", token)
+    text, url = (m.group(1), m.group(2)) if m else (token, "")
+    url_match = _GITHUB_REF_URL_RE.search(url)
+    if url_match:
+        return url_match.group(1), url_match.group(2)
+    text_match = _REF_TEXT_RE.match(text)
+    if text_match:
+        return text_match.group(1), text_match.group(2)
+    plain_match = re.fullmatch(r"#(\d+)", text)
+    if plain_match:
+        return API_REPO, plain_match.group(1)
+    return None
+
+
+def _issue_exists(owner: str, repo: str, num: str, token: str | None) -> bool | None:
+    """Check that a GitHub issue/PR exists. False on 404, None on lookup failure."""
+    try:
+        _http_get(f"https://api.github.com/repos/{owner}/{repo}/issues/{num}", token)
+    except urllib.error.HTTPError as err:
+        if err.code == 404:
+            return False
+        return None
+    except urllib.error.URLError:
+        return None
+    return True
+
+
+def _make_closes_resolver(token: str | None) -> Callable[[str], str | None]:
+    """Build the existence-check resolver for closes-tail issue numbers.
+
+    For a number it returns ``"api"`` (exists in the API repo), ``"kia_uvo"``
+    (404 there but exists in kia_uvo — a misattributed ref), ``None`` (missing
+    in both repos), or ``"unknown"`` (the check itself failed; callers fail
+    open). Results are cached per number.
+    """
+    cache: dict[str, str | None] = {}
+
+    def _resolve(num: str) -> str | None:
+        if num in cache:
+            return cache[num]
+        exists = _issue_exists(API_OWNER, API_REPO, num, token)
+        if exists is None:
+            result: str | None = "unknown"
+        elif exists:
+            result = "api"
+        else:
+            in_uvo = _issue_exists(API_OWNER, KIA_UVO_REPO, num, token)
+            result = "kia_uvo" if in_uvo else (None if in_uvo is False else "unknown")
+        cache[num] = result
+        return result
+
+    return _resolve
+
+
+def _sanitize_closes_refs(line: str, resolver: Callable[[str], str | None]) -> str:
+    """Rewrite a release-note line's ``closes ...`` tail for the kia_uvo bump.
+
+    Upstream API release notes derive their ``closes`` footers from squash-merge
+    commit messages, which embed the full PR body — including loose ``#NNN``
+    prose references. Those get resolved against the API repo even when they
+    point at kia_uvo issues (``#1652``, ``#1823``), emitted as shortname refs
+    that render as dead ``github.com/kia_uvo`` links, and duplicated across
+    forms.
+
+    A deps-bump release for kia_uvo should close kia_uvo issues only (API-side
+    context stays in the line's PR link), so this helper keeps kia_uvo refs in
+    full ``Hyundai-Kia-Connect/kia_uvo#N`` form and drops everything else:
+
+      - kia_uvo refs kept, deduplicated by issue number, URL canonicalized;
+      - API-repo refs resolved via ``resolver``: existing in the API repo ->
+        dropped; 404 there but present in kia_uvo -> rewritten (rescued
+        misattribution); missing in both repos -> dropped (dead link);
+        lookup failed -> token kept unchanged (fail-open);
+      - refs to any other repo -> token left untouched.
+
+    A tail whose refs all disappear loses its ``closes`` keyword too.
     """
     m = _CLOSES_TAIL_RE.match(line)
     if not m:
         return line
     head, tail = m.group(1), m.group(2)
     tokens = re.findall(r"\[[^\]]+\]\([^)]*\)|[^\s]+", tail)
+    kept: list[str] = []
     seen: set[str] = set()
-    deduped: list[str] = []
     for tok in tokens:
-        key = re.sub(r"\]\([^)]*\)$", "", tok).lstrip("[").rstrip("]")
-        if key in seen:
+        target = _ref_target(tok)
+        if target is None:
+            kept.append(tok)
             continue
-        seen.add(key)
-        deduped.append(tok)
-    return head + " ".join(deduped)
+        repo_name, num = target
+        if repo_name == KIA_UVO_REPO:
+            out = _kia_uvo_ref(num)
+        elif repo_name == API_REPO:
+            verdict = resolver(num)
+            if verdict == "kia_uvo":
+                out = _kia_uvo_ref(num)
+            elif verdict == "unknown":
+                out = tok  # fail-open: a possibly-wrong link beats a lost one
+            else:
+                continue  # verified API-repo ref, or missing in both repos
+        else:
+            out = tok  # ref to a repo we don't manage: leave untouched
+        if num in seen:
+            continue
+        seen.add(num)
+        kept.append(out)
+    if not kept:
+        return re.sub(r"[,\s]*closes\s*$", "", head, flags=re.IGNORECASE).rstrip()
+    return head + " ".join(kept)
 
 
 def _synthesize_body_from_commits(
@@ -182,13 +302,22 @@ def _synthesize_body_from_commits(
         lines.append("BREAKING CHANGES")
     if feat:
         lines.append("### Features")
-        lines.extend(_normalize_issue_refs(line, owner, repo) for line in feat)
+        lines.extend(
+            _qualify_short_repo_refs(_normalize_issue_refs(line, owner, repo))
+            for line in feat
+        )
     if fix:
         lines.append("### Bug Fixes")
-        lines.extend(_normalize_issue_refs(line, owner, repo) for line in fix)
+        lines.extend(
+            _qualify_short_repo_refs(_normalize_issue_refs(line, owner, repo))
+            for line in fix
+        )
     if not feat and not fix and other:
         lines.append("### Other Changes")
-        lines.extend(_normalize_issue_refs(line, owner, repo) for line in other)
+        lines.extend(
+            _qualify_short_repo_refs(_normalize_issue_refs(line, owner, repo))
+            for line in other
+        )
     return "\n".join(lines)
 
 
@@ -221,9 +350,13 @@ def _extract_section(body: str, headings: list[str]) -> str:
 
 
 def _classify_single_release(
-    body: str, owner: str = API_OWNER, repo: str = API_REPO
+    body: str,
+    owner: str = API_OWNER,
+    repo: str = API_REPO,
+    token: str | None = None,
 ) -> tuple[str, dict[str, list[str]]]:
-    body = _normalize_issue_refs(body or "", owner, repo)
+    body = _qualify_short_repo_refs(_normalize_issue_refs(body or "", owner, repo))
+    resolver = _make_closes_resolver(token)
     sections: dict[str, list[str]] = {
         "breaking": [],
         "features": [],
@@ -257,7 +390,9 @@ def _classify_single_release(
         sections["other"].extend(other)
 
     for _key in ("breaking", "features", "fixes", "other"):
-        sections[_key] = [_dedup_closes_refs(line) for line in sections.get(_key, [])]
+        sections[_key] = [
+            _sanitize_closes_refs(line, resolver) for line in sections.get(_key, [])
+        ]
 
     if not any(sections.values()):
         sections["other"].append("No categorized release notes.")
@@ -300,7 +435,7 @@ def classify_release_notes(
                 body = _synthesize_body_from_commits(compare.get("commits", []))
             except urllib.error.HTTPError:
                 body = ""
-        rel_level, sections = _classify_single_release(body, owner, repo)
+        rel_level, sections = _classify_single_release(body, owner, repo, token)
         if rel_level != "chore":
             level = max(
                 level, rel_level, key=["chore", "fix", "feat", "breaking"].index

--- a/tests/scripts/test_bump_api_dependency.py
+++ b/tests/scripts/test_bump_api_dependency.py
@@ -8,6 +8,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
 from bump_api_dependency import (
     _normalize_issue_refs,
+    _qualify_short_repo_refs,
+    _sanitize_closes_refs,
     classify_release_notes,
     get_current_pin,
     main,
@@ -152,7 +154,13 @@ def test_normalize_issue_refs_leaves_url_anchors_intact():
     assert body in normalized  # the #issuecomment anchor is not an issue ref
 
 
-def test_classify_release_notes_rewrites_api_issue_refs():
+def test_classify_release_notes_rewrites_pr_link_and_drops_api_closes(monkeypatch):
+    # Bare closes refs read as API-repo refs; existing ones are dropped from the
+    # bump PR body (API context stays in the line's PR link), the PR link itself
+    # is still qualified.
+    monkeypatch.setattr(
+        "bump_api_dependency._issue_exists", lambda _o, _r, _n, _t: True
+    )
     releases = [
         {
             "tag_name": "v4.22.1",
@@ -160,9 +168,10 @@ def test_classify_release_notes_rewrites_api_issue_refs():
         }
     ]
     _commit_type, body = classify_release_notes(releases, "4.22.0")
-    assert "Hyundai-Kia-Connect/hyundai_kia_connect_api#1155" in body
-    assert "Hyundai-Kia-Connect/hyundai_kia_connect_api#1153" in body
-    assert "[#1156]" not in body  # markdown link text qualified
+    assert "Hyundai-Kia-Connect/hyundai_kia_connect_api#1156" in body  # PR link kept
+    assert "closes" not in body  # API closes dropped, keyword removed with them
+    assert "#1155" not in body
+    assert "#1153" not in body
 
 
 def test_update_manifest(tmp_path):
@@ -295,78 +304,135 @@ def test_main_at_latest_is_noop(tmp_path, monkeypatch, capsys):
     assert "already at latest version" in captured.out
 
 
-from bump_api_dependency import _dedup_closes_refs
-
-
-def test_dedup_closes_refs_no_closes_unchanged():
+def test_sanitize_closes_refs_no_closes_unchanged():
     line = "- 4.26.0: * **CCS2:** parse ev_driving_range for PHEV from DTE.EV ([Hyundai-Kia-Connect/hyundai_kia_connect_api#1261](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1261)) ([584d242](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/commit/584d242))"
-    assert _dedup_closes_refs(line) == line
+
+    def _fail(_num):
+        raise AssertionError("resolver must not be called without a closes tail")
+
+    assert _sanitize_closes_refs(line, _fail) == line
 
 
-def test_dedup_closes_refs_removes_duplicates():
-    # Real v4.26.0 line, post-normalization: api#1195, kia_uvo#1739, kia_uvo#1447
-    # each appear twice; api#1447 is a distinct ticket from kia_uvo#1447.
+def test_sanitize_closes_refs_dedups_kia_uvo_by_number():
+    # Real v4.27.2 shape: the same kia_uvo ticket appears twice in the closes
+    # tail (once canonical, once short-form with a dead github.com/kia_uvo URL).
     line = (
-        "- 4.26.0: * **CCS2:** start_climate sideRearMirrorHeating + RHD front seat swap "
-        "([Hyundai-Kia-Connect/hyundai_kia_connect_api#1260](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1260)) "
-        "(a9c5303), closes "
-        "[Hyundai-Kia-Connect/hyundai_kia_connect_api#1195](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1195) "
-        "[Hyundai-Kia-Connect/kia_uvo#1739](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1739) "
-        "[Hyundai-Kia-Connect/kia_uvo#1447](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1447) "
-        "[Hyundai-Kia-Connect/hyundai_kia_connect_api#1447](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1447) "
-        "[Hyundai-Kia-Connect/hyundai_kia_connect_api#1195](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1195) "
-        "[Hyundai-Kia-Connect/kia_uvo#1739](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1739) "
-        "[Hyundai-Kia-Connect/kia_uvo#1447](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1447)"
+        "- 4.27.2: * **ccs2:** map BatteryPreCondition.Status per the official app "
+        "([Hyundai-Kia-Connect/hyundai_kia_connect_api#1293](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1293)) "
+        "([e90f16c](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/commit/e90f16c)), closes "
+        "[Hyundai-Kia-Connect/kia_uvo#1823](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1823) "
+        "[kia_uvo#1823](https://github.com/kia_uvo/issues/1823) "
+        "[Hyundai-Kia-Connect/kia_uvo#1823](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1823)"
     )
-    result = _dedup_closes_refs(line)
-    # Each duplicated ref appears exactly once.
-    assert result.count("hyundai_kia_connect_api#1195") == 1
-    assert result.count("kia_uvo#1739") == 1
-    assert result.count("kia_uvo#1447") == 1
-    # Distinct ticket retained.
-    assert "hyundai_kia_connect_api#1447" in result
-    # Order preserved: api#1195 before kia_uvo#1739 before kia_uvo#1447 before api#1447.
-    idx_1195 = result.index("hyundai_kia_connect_api#1195")
-    idx_1739 = result.index("kia_uvo#1739")
-    idx_1447_kia = result.index("kia_uvo#1447")
-    idx_1447_api = result.index("hyundai_kia_connect_api#1447")
-    assert idx_1195 < idx_1739 < idx_1447_kia < idx_1447_api
-    # First occurrence's URL preserved.
-    assert "issues/1195)" in result
+
+    def _fail(_num):
+        raise AssertionError("resolver must not be called for kia_uvo refs")
+
+    result = _sanitize_closes_refs(line, _fail)
+    assert result.count("closes") == 1
+    assert result.count("kia_uvo#1823") == 1
+    # Canonical URL rebuilt even for the short-form ref with the dead URL.
+    assert (
+        "[Hyundai-Kia-Connect/kia_uvo#1823](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1823)"
+        in result
+    )
+    assert "github.com/kia_uvo/" not in result
+    # The bump PR link in the line body is untouched.
+    assert "hyundai_kia_connect_api#1293" in result
 
 
-def test_dedup_closes_refs_keeps_first_occurrence_order():
-    line = "closes api#1 api#2 api#1 api#3"
-    assert _dedup_closes_refs(line) == "closes api#1 api#2 api#3"
+def test_sanitize_closes_refs_drops_existing_api_refs():
+    # api#1259 is a merged API PR — it exists, but is not a kia_uvo close.
+    line = (
+        "- 4.27.1: * **BR:** surface 4xx body ([#1285](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1285)) "
+        "(b9661b4), closes "
+        "[Hyundai-Kia-Connect/hyundai_kia_connect_api#1259](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1259)"
+    )
+    result = _sanitize_closes_refs(line, lambda _num: "api")
+    assert "closes" not in result
+    assert "#1259" not in result
+    assert result.rstrip().endswith("(b9661b4)")
 
 
-def test_classify_release_notes_dedup_in_pipeline():
-    # Upstream body with duplicate closes refs in a fix line.
+def test_sanitize_closes_refs_rescues_misattributed_api_ref():
+    # #1652/#1823 are kia_uvo issues that landed in the notes as API-repo refs
+    # (bare #N resolved against the API repo).
+    line = (
+        "- 4.27.2: * **ccs2:** fix ([#1293](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1293)), closes "
+        "[Hyundai-Kia-Connect/hyundai_kia_connect_api#1652](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1652) "
+        "[Hyundai-Kia-Connect/hyundai_kia_connect_api#1823](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1823)"
+    )
+    result = _sanitize_closes_refs(
+        line, lambda num: "kia_uvo" if num in {"1652", "1823"} else "api"
+    )
+    assert result.count("kia_uvo#1652") == 1
+    assert result.count("kia_uvo#1823") == 1
+    assert "hyundai_kia_connect_api/issues/1652" not in result
+
+
+def test_sanitize_closes_refs_drops_refs_missing_in_both_repos():
+    line = "- 4.27.1: * fix something ([#1285](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1285)), closes [Hyundai-Kia-Connect/hyundai_kia_connect_api#999999](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/999999)"
+    result = _sanitize_closes_refs(line, lambda _num: None)
+    assert "closes" not in result
+    assert "#999999" not in result
+
+
+def test_sanitize_closes_refs_fails_open_on_unknown():
+    # Resolver can't decide (network error): keep the token as-is.
+    line = "- 4.27.1: * fix something ([#1285](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1285)), closes [Hyundai-Kia-Connect/hyundai_kia_connect_api#1259](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1259)"
+    result = _sanitize_closes_refs(line, lambda _num: "unknown")
+    assert "closes" in result
+    assert "hyundai_kia_connect_api#1259" in result
+
+
+def test_sanitize_closes_refs_keeps_foreign_repo_refs():
+    line = "- 4.27.1: * fix something ([#1285](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1285)), closes [acme/other#42](https://github.com/acme/other/issues/42)"
+    result = _sanitize_closes_refs(line, lambda _num: "api")
+    assert "[acme/other#42](https://github.com/acme/other/issues/42)" in result
+
+
+def test_qualify_short_repo_refs():
+    body = (
+        "exact reporter-dump case from kia_uvo#1823 and hyundai_kia_connect_api#1195; "
+        "full Hyundai-Kia-Connect/kia_uvo#1823 stays untouched"
+    )
+    result = _qualify_short_repo_refs(body)
+    assert "case from Hyundai-Kia-Connect/kia_uvo#1823 and" in result
+    assert "Hyundai-Kia-Connect/hyundai_kia_connect_api#1195;" in result
+    # The already-qualified full form was not re-qualified (still one occurrence).
+    assert result.count("Hyundai-Kia-Connect/kia_uvo#1823") == 2
+
+
+def test_classify_release_notes_v4272_real_body(monkeypatch):
+    # Regression test from kia_uvo release v3.11.0: upstream v4.27.2 notes
+    # carried a duplicated closes tail mixing a dead shortname link
+    # (github.com/kia_uvo — no such repo) with API-repo refs for kia_uvo
+    # tickets (#1652, #1823).
+    monkeypatch.setattr(
+        "bump_api_dependency._issue_exists",
+        lambda _o, repo, _n, _t: repo == "kia_uvo",
+    )
     releases = [
         {
-            "tag_name": "v4.26.0",
+            "tag_name": "v4.27.2",
             "body": (
-                "### Bug Fixes\n"
-                "* **CCS2:** start_climate sideRearMirrorHeating + RHD front seat swap "
-                "([#1260](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1260)) "
-                "(a9c5303), closes "
-                "[Hyundai-Kia-Connect/hyundai_kia_connect_api#1195](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1195) "
-                "[Hyundai-Kia-Connect/kia_uvo#1739](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1739) "
-                "[Hyundai-Kia-Connect/kia_uvo#1447](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1447) "
-                "[Hyundai-Kia-Connect/hyundai_kia_connect_api#1447](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1447) "
-                "[Hyundai-Kia-Connect/hyundai_kia_connect_api#1195](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1195) "
-                "[Hyundai-Kia-Connect/kia_uvo#1739](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1739) "
-                "[Hyundai-Kia-Connect/kia_uvo#1447](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1447)\n"
+                "### Bug Fixes\n\n"
+                "* **ccs2:** map BatteryPreCondition.Status per the official app (0/2/6 off, 3/4 on) "
+                "([#1293](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1293)) "
+                "([e90f16c](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/commit/e90f16c150ccf1eeee2e616c6061162865a9b14b)), closes "
+                "[Hyundai-Kia-Connect/kia_uvo#1823](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1823) "
+                "[kia_uvo#1823](https://github.com/kia_uvo/issues/1823) "
+                "[#1652](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1652) "
+                "[#1823](https://github.com/Hyundai-Kia-Connect/hyundai_kia_connect_api/issues/1823) "
+                "[Hyundai-Kia-Connect/kia_uvo#1823](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1823)\n"
             ),
         }
     ]
-    _commit_type, body = classify_release_notes(releases, "4.25.6")
-    # Each duplicated ref appears exactly once in the aggregated PR body.
-    assert body.count("hyundai_kia_connect_api#1195") == 1
-    assert body.count("kia_uvo#1739") == 1
-    assert body.count("kia_uvo#1447") == 1
-    # Distinct ticket retained.
-    assert "hyundai_kia_connect_api#1447" in body
-    # Section structure intact.
+    _commit_type, body = classify_release_notes(releases, "4.27.1")
+    # Exactly one, correct, fully-qualified kia_uvo ref survives.
+    assert body.count("Hyundai-Kia-Connect/kia_uvo#1823") == 1
+    assert "github.com/kia_uvo/" not in body  # dead shortname URL gone
+    assert "hyundai_kia_connect_api/issues/1652" not in body  # misattribution rescued
+    assert "hyundai_kia_connect_api/issues/1823" not in body
     assert "### Bug Fixes" in body
-    assert "- 4.26.0:" in body
+    assert "- 4.27.2:" in body


### PR DESCRIPTION
## Problem

kia_uvo release notes for deps bumps carried broken closes references — seen in [v3.11.0](https://github.com/Hyundai-Kia-Connect/kia_uvo/releases/tag/v3.11.0):

- dead shortname links: `kia_uvo#1823` renders as `https://github.com/kia_uvo/issues/1823` (no such repo)
- wrong-repo links: `[#1652]` / `[#1823]` / `[#1395]` are kia_uvo issues, but appear as `Hyundai-Kia-Connect/hyundai_kia_connect_api#N` (404)
- a merged API PR listed under closes (`#1259`)
- duplicates across token forms (`kia_uvo#1823` appears 3x)

## Root cause

Upstream API release notes derive their `closes` footers from squash-merge commit messages, which embed the full PR body — including loose prose references (`#1652`, `kia_uvo#1823`). semantic-release resolves bare `#N` against the API repo and copies `shortname#N` verbatim; the bump script then copies the notes into the bump PR body, and semantic-release here emits them into the kia_uvo release.

## Change

In `scripts/bump_api_dependency.py`, the closes tails of the generated bump PR body are sanitized to contain only kia_uvo issues in full `Hyundai-Kia-Connect/kia_uvo#N` form, deduplicated by issue number with canonical URLs:

- `_qualify_short_repo_refs`: rewrites bare shortname refs (`kia_uvo#1823`) to the full form everywhere in the notes
- `_dedup_closes_refs` → `_sanitize_closes_refs`: per closes tail, repo/number are taken from each token's github URL (falling back to its text); kia_uvo refs are kept canonicalized; API-repo refs are existence-checked via the GitHub API (`_issue_exists`, results cached):
  - exists in the API repo (merged PR or API issue) → dropped — API context stays in the line's PR link
  - 404 in the API repo but present in kia_uvo → rewritten as a kia_uvo ref (rescues the misattributed `#1652`/`#1823`/`#1395`)
  - missing in both repos → dropped (dead link)
  - lookup failure → token kept unchanged (fail-open)
- refs to any other repo pass through untouched; a tail whose refs all disappear loses its `closes` keyword

Workflow token is threaded into `_classify_single_release` for the existence checks; no workflow YAML change.

## Example

The real v4.27.2 notes line, after this change (offline reproduction with existence checks matching reality):

```
closes [Hyundai-Kia-Connect/kia_uvo#1823](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1823) [Hyundai-Kia-Connect/kia_uvo#1652](https://github.com/Hyundai-Kia-Connect/kia_uvo/issues/1652)
```

versus the current v3.11.0 tail with 5 broken/duplicate refs.

## Verification

- `uvx ruff@0.16.4 check/format` on all tracked `.py` — clean (matches the pre-commit pin)
- `pytest tests/scripts/test_bump_api_dependency.py` — 26 passed; full suite collection errors are pre-existing (no `homeassistant` in the local env)
- New regression test feeds the actual v4.27.2 release body through `classify_release_notes`

Closes none; this only affects future bump PRs — existing release bodies are unchanged.