### PR TITLE
refactor: mypy --strict for platform files (phase 2)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,13 +32,22 @@ jobs:
         run: |
           pip install mypy==2.3.1 homeassistant==2026.2.3 hyundai_kia_connect_api==4.27.2
       - name: Run mypy
-        # Phase 1: core non-platform files. Extend to the whole
-        # custom_components/kia_uvo/ package once the platform files are
-        # strict-clean as well.
+        # Phase 2: core non-platform files + platform files except sensor.py.
+        # Extend to the whole custom_components/kia_uvo/ package (sensor.py is
+        # the last remaining file) once it is strict-clean as well.
         run: |
           mypy --strict --ignore-missing-imports \
             custom_components/kia_uvo/__init__.py \
             custom_components/kia_uvo/config_flow.py \
             custom_components/kia_uvo/coordinator.py \
             custom_components/kia_uvo/entity.py \
-            custom_components/kia_uvo/services.py
+            custom_components/kia_uvo/services.py \
+            custom_components/kia_uvo/binary_sensor.py \
+            custom_components/kia_uvo/button.py \
+            custom_components/kia_uvo/climate.py \
+            custom_components/kia_uvo/cover.py \
+            custom_components/kia_uvo/device_tracker.py \
+            custom_components/kia_uvo/lock.py \
+            custom_components/kia_uvo/number.py \
+            custom_components/kia_uvo/switch.py \
+            custom_components/kia_uvo/time.py

--- a/custom_components/kia_uvo/binary_sensor.py
+++ b/custom_components/kia_uvo/binary_sensor.py
@@ -25,7 +25,7 @@ from .entity import HyundaiKiaConnectEntity
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(frozen=True, kw_only=True)
 class HyundaiKiaBinarySensorEntityDescription(BinarySensorEntityDescription):
     """A class that describes custom binary sensor entities."""
 
@@ -574,7 +574,6 @@ async def async_setup_entry(
                     HyundaiKiaConnectBinarySensor(coordinator, description, vehicle)
                 )
     async_add_entities(entities)
-    return True
 
 
 PARALLEL_UPDATES = 0
@@ -604,12 +603,12 @@ class HyundaiKiaConnectBinarySensor(BinarySensorEntity, HyundaiKiaConnectEntity)
         return None
 
     @property
-    def icon(self):
+    def icon(self) -> str | None:
         """Return the icon to use in the frontend, if any."""
         if (
             self.entity_description.on_icon == self.entity_description.off_icon
         ) is None:
-            return BinarySensorEntity.icon
+            return BinarySensorEntity.icon.__get__(self)
         return (
             self.entity_description.on_icon
             if self.is_on

--- a/custom_components/kia_uvo/button.py
+++ b/custom_components/kia_uvo/button.py
@@ -124,7 +124,7 @@ class HyundaiKiaConnectButton(ButtonEntity, HyundaiKiaConnectEntity):
         vehicle: Vehicle,
     ) -> None:
         HyundaiKiaConnectEntity.__init__(self, coordinator, vehicle)
-        self.entity_description = description
+        self.entity_description: HyundaiKiaButtonDescription = description
         self._key = description.key
         self._attr_unique_id = f"{DOMAIN}_{vehicle.id}_{self._key}"
         self._attr_icon = description.icon

--- a/custom_components/kia_uvo/climate.py
+++ b/custom_components/kia_uvo/climate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import ClassVar
+from typing import Any, ClassVar, cast
 
 from homeassistant.components.climate import ClimateEntity, ClimateEntityDescription
 from homeassistant.components.climate.const import (
@@ -64,7 +64,7 @@ class HyundaiKiaCarClimateControlSwitch(HyundaiKiaConnectEntity, ClimateEntity):
         v: k for [k, v] in heat_status_int_to_str.items()
     }
 
-    def get_internal_heat_int_for_climate_request(self):
+    def get_internal_heat_int_for_climate_request(self) -> int:
         if (
             self.vehicle.steering_wheel_heater_is_on
             and self.vehicle.back_window_heater_is_on
@@ -110,13 +110,13 @@ class HyundaiKiaCarClimateControlSwitch(HyundaiKiaConnectEntity, ClimateEntity):
     @property
     def current_temperature(self) -> float | None:
         """Get the current in-car temperature."""
-        return self.vehicle.air_temperature
+        return cast(float | None, self.vehicle.air_temperature)
 
     @property
     def target_temperature(self) -> float | None:
         """Get the desired in-car target temperature."""
         # TODO: use Coordinator data, not internal state
-        return self.climate_config.set_temp
+        return cast(float | None, self.climate_config.set_temp)
 
     @property
     def target_temperature_step(self) -> float | None:
@@ -143,7 +143,7 @@ class HyundaiKiaCarClimateControlSwitch(HyundaiKiaConnectEntity, ClimateEntity):
         return 30
 
     @property
-    def hvac_mode(self) -> str:
+    def hvac_mode(self) -> HVACMode | None:
         """Get the configured climate control operation mode."""
 
         if not self.vehicle.air_control_is_on:
@@ -165,7 +165,7 @@ class HyundaiKiaCarClimateControlSwitch(HyundaiKiaConnectEntity, ClimateEntity):
         return HVACMode.AUTO
 
     @property
-    def hvac_action(self) -> str | None:
+    def hvac_action(self) -> HVACAction | None:
         # TODO: use Coordinator data, not internal state
         """
         Get what the in-car climate control is currently doing.
@@ -195,7 +195,7 @@ class HyundaiKiaCarClimateControlSwitch(HyundaiKiaConnectEntity, ClimateEntity):
         return HVACAction.OFF
 
     @property
-    def hvac_modes(self) -> list[str]:
+    def hvac_modes(self) -> list[HVACMode]:
         """Supported in-car climate control modes."""
         return [
             HVACMode.OFF,
@@ -206,11 +206,11 @@ class HyundaiKiaCarClimateControlSwitch(HyundaiKiaConnectEntity, ClimateEntity):
         ]
 
     @property
-    def supported_features(self) -> int:
+    def supported_features(self) -> ClimateEntityFeature:
         """Supported in-car climate control features."""
         return ClimateEntityFeature.TARGET_TEMPERATURE
 
-    async def async_set_hvac_mode(self, hvac_mode):
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the operation mode of the in-car climate control."""
 
         if hvac_mode == HVACMode.OFF:
@@ -221,7 +221,7 @@ class HyundaiKiaCarClimateControlSwitch(HyundaiKiaConnectEntity, ClimateEntity):
             )
         self.async_write_ha_state()
 
-    async def async_set_temperature(self, **kwargs):
+    async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set the desired in-car temperature. Does not turn on the AC."""
         old_temp = self.climate_config.set_temp
         self.climate_config.set_temp = kwargs.get(ATTR_TEMPERATURE)

--- a/custom_components/kia_uvo/cover.py
+++ b/custom_components/kia_uvo/cover.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Final
+from typing import Any, Final
 
 from homeassistant.components.cover import (
+    ATTR_POSITION,
     CoverEntity,
     CoverEntityDescription,
     CoverEntityFeature,
@@ -97,7 +98,7 @@ class HyundaiKiaConnectCover(CoverEntity, HyundaiKiaConnectEntity):
         vehicle: Vehicle,
     ) -> None:
         HyundaiKiaConnectEntity.__init__(self, coordinator, vehicle)
-        self.entity_description = description
+        self.entity_description: HyundaiKiaCoverDescription = description
         self._attr_unique_id = f"{DOMAIN}_{vehicle.id}_{description.key}"
 
     @property
@@ -116,25 +117,26 @@ class HyundaiKiaConnectCover(CoverEntity, HyundaiKiaConnectEntity):
             return 100
         return 0
 
-    async def async_open_cover(self, **kwargs) -> None:
+    async def async_open_cover(self, **kwargs: Any) -> None:
         options = WindowRequestOptions(
             **{self.entity_description.window_position: WINDOW_STATE.OPEN}
         )
         await self.coordinator.async_set_windows(self.vehicle.id, options)
 
-    async def async_close_cover(self, **kwargs) -> None:
+    async def async_close_cover(self, **kwargs: Any) -> None:
         options = WindowRequestOptions(
             **{self.entity_description.window_position: WINDOW_STATE.CLOSED}
         )
         await self.coordinator.async_set_windows(self.vehicle.id, options)
 
-    async def async_stop_cover(self, **kwargs) -> None:
+    async def async_stop_cover(self, **kwargs: Any) -> None:
         options = WindowRequestOptions(
             **{self.entity_description.window_position: WINDOW_STATE.CLOSED}
         )
         await self.coordinator.async_set_windows(self.vehicle.id, options)
 
-    async def async_set_cover_position(self, position: int, **kwargs) -> None:
+    async def async_set_cover_position(self, **kwargs: Any) -> None:
+        position = kwargs[ATTR_POSITION]
         if position == 0:
             state = WINDOW_STATE.CLOSED
         elif position <= 49:

--- a/custom_components/kia_uvo/device_tracker.py
+++ b/custom_components/kia_uvo/device_tracker.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import logging
+from typing import cast
 
-from homeassistant.components.device_tracker import TrackerEntity
+from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.components.device_tracker.const import SourceType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -31,7 +32,6 @@ async def async_setup_entry(
             entities.append(HyundaiKiaConnectTracker(coordinator, vehicle))
 
     async_add_entities(entities)
-    return True
 
 
 PARALLEL_UPDATES = 0
@@ -42,20 +42,20 @@ class HyundaiKiaConnectTracker(TrackerEntity, HyundaiKiaConnectEntity):
         self,
         coordinator: HyundaiKiaConnectDataUpdateCoordinator,
         vehicle: Vehicle,
-    ):
+    ) -> None:
         HyundaiKiaConnectEntity.__init__(self, coordinator, vehicle)
         self._attr_unique_id = f"{DOMAIN}_{vehicle.id}_location"
         self._attr_translation_key = "location"
         self._attr_icon = "mdi:map-marker-outline"
 
     @property
-    def latitude(self):
-        return self.vehicle.location_latitude
+    def latitude(self) -> float | None:
+        return cast(float | None, self.vehicle.location_latitude)
 
     @property
-    def longitude(self):
-        return self.vehicle.location_longitude
+    def longitude(self) -> float | None:
+        return cast(float | None, self.vehicle.location_longitude)
 
     @property
-    def source_type(self):
+    def source_type(self) -> SourceType:
         return SourceType.GPS

--- a/custom_components/kia_uvo/lock.py
+++ b/custom_components/kia_uvo/lock.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any, cast
 
 from homeassistant.components.lock import LockEntity
 from homeassistant.config_entries import ConfigEntry
@@ -29,7 +30,6 @@ async def async_setup_entry(
         entities.append(HyundaiKiaConnectLock(coordinator, vehicle))
 
     async_add_entities(entities)
-    return True
 
 
 PARALLEL_UPDATES = 1
@@ -40,21 +40,21 @@ class HyundaiKiaConnectLock(LockEntity, HyundaiKiaConnectEntity):
         self,
         coordinator: HyundaiKiaConnectDataUpdateCoordinator,
         vehicle: Vehicle,
-    ):
+    ) -> None:
         HyundaiKiaConnectEntity.__init__(self, coordinator, vehicle)
         self._attr_unique_id = f"{DOMAIN}_{vehicle.id}_door_lock"
         self._attr_translation_key = "door_lock"
 
     @property
-    def icon(self):
+    def icon(self) -> str | None:
         return "mdi:lock" if self.is_locked else "mdi:lock-open-variant"
 
     @property
-    def is_locked(self):
-        return self.vehicle.is_locked
+    def is_locked(self) -> bool | None:
+        return cast(bool | None, self.vehicle.is_locked)
 
-    async def async_lock(self, **kwargs):
+    async def async_lock(self, **kwargs: Any) -> None:
         await self.coordinator.async_lock_vehicle(self.vehicle.id)
 
-    async def async_unlock(self, **kwargs):
+    async def async_unlock(self, **kwargs: Any) -> None:
         await self.coordinator.async_unlock_vehicle(self.vehicle.id)

--- a/custom_components/kia_uvo/number.py
+++ b/custom_components/kia_uvo/number.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Final
+from typing import Final, cast
 
 from homeassistant.components.number import (
     NumberEntity,
@@ -74,7 +74,6 @@ async def async_setup_entry(
                 )
 
     async_add_entities(entities)
-    return True
 
 
 PARALLEL_UPDATES = 1
@@ -98,10 +97,10 @@ class HyundaiKiaConnectNumber(NumberEntity, HyundaiKiaConnectEntity):
     @property
     def native_value(self) -> float | None:
         """Return the entity value to represent the entity state."""
-        return getattr(self.vehicle, self._key)
+        return cast(float | None, getattr(self.vehicle, self._key))
 
     @staticmethod
-    def _is_valid_charge_limit(val) -> bool:
+    def _is_valid_charge_limit(val: float | None) -> bool:
         """Check if a charge limit value is a valid integer 50-100 in steps of 10."""
         return isinstance(val, (int, float)) and int(val) in range(50, 101, 10)
 
@@ -152,30 +151,29 @@ class HyundaiKiaConnectNumber(NumberEntity, HyundaiKiaConnectEntity):
                 )
             await self.coordinator.async_set_charge_limits(self.vehicle.id, int(ac), dc)
         elif self.entity_description.key == V2L_LIMIT_KEY:
-            v2l = value
-            await self.coordinator.async_set_v2l_limit(self.vehicle.id, v2l)
+            await self.coordinator.async_set_v2l_limit(self.vehicle.id, int(value))
 
         self.async_write_ha_state()
 
     @property
-    def native_min_value(self):
+    def native_min_value(self) -> float:
         """Return native_min_value as reported in by the sensor"""
-        return self.entity_description.native_min_value
+        return cast(float, self.entity_description.native_min_value)
 
     @property
-    def native_max_value(self):
+    def native_max_value(self) -> float:
         """Returnnative_max_value as reported in by the sensor"""
-        return self.entity_description.native_max_value
+        return cast(float, self.entity_description.native_max_value)
 
     @property
-    def native_step(self):
+    def native_step(self) -> float | None:
         """Return step value as reported in by the sensor"""
         return self.entity_description.native_step
 
     @property
-    def native_unit_of_measurement(self):
+    def native_unit_of_measurement(self) -> str | None:
         """Return the unit the value was reported in by the sensor"""
         if self.entity_description.native_unit_of_measurement == DYNAMIC_UNIT:
-            return getattr(self.vehicle, self._key + "_unit")
+            return cast(str | None, getattr(self.vehicle, self._key + "_unit"))
         else:
             return self.entity_description.native_unit_of_measurement


### PR DESCRIPTION
Follows up on the phase 1 mypy --strict rollout (#1857): the same CI job now also covers the platform files annotated here.

## Scope

All platform files except `sensor.py` are now strict-clean and added to the `validate-mypy` job in `.github/workflows/validate.yml`. `sensor.py` is intentionally deferred: it has concurrent open PRs (Hyundai-Kia-Connect/kia_uvo#1856, Hyundai-Kia-Connect/kia_uvo#1745) touching it, so annotating it now would only cause rebase churn. Once those land, sensor.py closes the rollout and the job switches from the file list to the whole `custom_components/kia_uvo/` package.

## Per-file changes

- **climate**: override return types now match the HA 2026.2.3 base entity — `HVACMode | None`, `HVACAction | None`, `list[HVACMode]`, `ClimateEntityFeature` (base entity types changed from the loose `str`/`int` the overrides were written against); lib-boundary reads cast (the lib has no `py.typed`, so everything reads as `Any` under mypy).
- **cover**: `async_set_cover_position` now matches the base signature (`**kwargs`) and reads the position from `ATTR_POSITION`, like HA core components do (the base method takes no positional `position` argument); typed `entity_description` narrows to `HyundaiKiaCoverDescription`, which fixes the four `window_position` accesses.
- **number**: dropped the stray `return True` at the end of `async_setup_entry` (ignored by HA); the V2L limit is passed to the coordinator as `int` (matches `async_set_v2l_limit` and the step-10 slider); casts on lib-boundary reads.
- **lock, device_tracker**: annotations plus casts on lib-boundary reads; `TrackerEntity` is imported from `homeassistant.components.device_tracker.config_entry` (the `__init__` re-export is not explicit under mypy).
- **binary_sensor**: `HyundaiKiaBinarySensorEntityDescription` is now a frozen dataclass — required to subclass the frozen base, and consistent with the existing frozen description dataclasses in switch/cover/button. While annotating `icon`, the default-icon fallback branch turned out to be dead code returning the cached_property descriptor object (`(a == b) is None` is never true for `str | None` operands); it now calls the base icon property properly (`BinarySensorEntity.icon.__get__(self)`).
- **button**: typed `entity_description` narrows to `HyundaiKiaButtonDescription`, fixing the `press_action` access.
- **switch, time**: already strict-clean, no changes; added to the CI list only.

## Verification

- `mypy --strict --ignore-missing-imports` (mypy 2.3.1, homeassistant 2026.2.3, hyundai_kia_connect_api 4.27.2 per manifest): 0 issues across all 14 files in the job list.
- pytest: 71 passed.
- ruff (pinned pre-commit version) and pre-commit `--all-files`: clean.