### PR TITLE
feat: add MyHyundai Korea config flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ A custom integration for Kia Uvo / Hyundai Bluelink. This project uses our under
 
 ### Configuration
 
-After installation, go to **Settings** → **Devices & Services** → **Integrations** and search for **Kia Uvo**. Configure your vehicle using your username and password.
+After installation, go to **Settings** → **Devices & Services** → **Integrations** and search for **Kia Uvo**. Configure your vehicle using your username and password. MyHyundai Korea uses the browser login described below instead of storing an account password.
 
-- AU, EU, CA, CH, IN, NZ, BR and US is supported. USA, India, China and Brazil support is limited.
+- AU, EU, CA, CH, IN, NZ, BR, KR and US are supported. USA, India, China, Brazil and Korea support is limited.
 - Genesis Support hasn't been tested and has just been added for Canada only. Feedback would be appreciated!
 - Multiple cars and accounts are supported. To add additional accounts just go through setup a second time.
 - Reconfigure flow is available from the integration options (change credentials or set PIN).
@@ -36,6 +36,17 @@ After installation, go to **Settings** → **Devices & Services** → **Integrat
 - Force Refresh Interval - asks your car for the latest data every 4 hours. **Configurable**
 - Force Refresh is disabled between 10PM and 6AM by default. **Configurable**
 - By default, distance unit is based on HA metric/imperial preference, you need to configure each entity if you would like other units.
+
+#### MyHyundai Korea login
+
+Choose **Korea** and **Hyundai** in the config flow. Home Assistant will show a MyHyundai authorization link. The registered OAuth callback forwards desktop browsers immediately, so capture it with the browser network log:
+
+1. Open the browser developer tools and select **Network**.
+2. Enable **Preserve log**, then open the authorization link and sign in with Pleos.
+3. After the browser reaches the Hyundai website, filter the requests for `oneapp.hyundai.com/redirect`.
+4. Copy that request's complete URL and paste it into Home Assistant with your vehicle-control PIN.
+
+Home Assistant stores the renewable token set in the config entry. It does not store the MyHyundai account password. The integration saves rotated refresh credentials after each token refresh. Browser login is only required again if Hyundai expires or revokes those credentials.
 
 ## Supported entities
 
@@ -135,22 +146,22 @@ These can be accessed via Developer Tools > Actions, or called from automations.
 
 ### Service availability by region
 
-| Service                       | EU  | EU(>2023), NZ, AU | CA  | USA Kia | USA Hyundai | USA Genesis | China | India | Brazil |
-| ----------------------------- | --- | ----------------- | --- | ------- | ----------- | ----------- | ----- | ----- | ------ |
-| Update                        | ✔   | ✔                 | ✔   | ✔       | ✔           | ✔           | ✔     | ✔     | ✔      |
-| Force Update                  | ✔   | not tested        | ✔   | ✔       |             |             | ✔     | ✔     | ✔      |
-| Lock / Unlock                 | ✔   | ✔                 | ✔   | ✔       | ✔           | ✔           | ✔     | ✔     | ✖      |
-| Start / Stop Climate          | ✔   | ✔                 | ✔   | ✔       | ✔           |             | ✔     | ✔     | ✖      |
-| Start / Stop Charge           | ✔   | ✔                 | ✔   | ✔       | ✔           |             |       |       | ✖      |
-| Set Charge Limits             | ✔   | ✔                 | ✔   | ✔       | ✔           |             |       |       | ✖      |
-| Set Charging Current          | ✔   | ✔                 | ✔   | ✔       | ✔           |             |       |       | ✖      |
-| Open / Close Charge Port      | ✖   | ✔                 | ✖   | ✖       | ✖           | ✖           | ✖     |       | ✖      |
-| Set Windows                   | ✖   | ✔                 | ✖   | ✖       | ✖           | ✖           | ✖     |       | ✖      |
-| Start / Stop Hazard Lights    | ✖   | ✔                 | ✖   | ✖       | ✖           | ✖           | ✖     |       | ✖      |
-| Start / Stop Hazard + Horn    | ✖   | ✔                 | ✖   | ✖       | ✖           | ✖           | ✖     | ✔     | ✖      |
-| Schedule Charging and Climate | ✖   | ✔                 | ✖   | ✖       | ✖           | ✖           | ✖     |       | ✖      |
-| Start / Stop Valet Mode       | ✖   | ✔                 | ✖   | ✖       | ✖           | ✖           | ✖     |       | ✖      |
-| Set Navigation _(WIP)_        |     | ✔                 |     |         |             |             |       |       |        |
+| Service                       | EU  | EU(>2023), NZ, AU | CA  | USA Kia | USA Hyundai | USA Genesis | China | India | Brazil | Korea |
+| ----------------------------- | --- | ----------------- | --- | ------- | ----------- | ----------- | ----- | ----- | ------ | ----- |
+| Update                        | ✔   | ✔                 | ✔   | ✔       | ✔           | ✔           | ✔     | ✔     | ✔      | ✔     |
+| Force Update                  | ✔   | not tested        | ✔   | ✔       |             |             | ✔     | ✔     | ✔      | ✔     |
+| Lock / Unlock                 | ✔   | ✔                 | ✔   | ✔       | ✔           | ✔           | ✔     | ✔     | ✖      | ✔     |
+| Start / Stop Climate          | ✔   | ✔                 | ✔   | ✔       | ✔           |             | ✔     | ✔     | ✖      | ✔     |
+| Start / Stop Charge           | ✔   | ✔                 | ✔   | ✔       | ✔           |             |       |       | ✖      | ✖     |
+| Set Charge Limits             | ✔   | ✔                 | ✔   | ✔       | ✔           |             |       |       | ✖      | ✖     |
+| Set Charging Current          | ✔   | ✔                 | ✔   | ✔       | ✔           |             |       |       | ✖      | ✖     |
+| Open / Close Charge Port      | ✖   | ✔                 | ✖   | ✖       | ✖           | ✖           | ✖     |       | ✖      | ✖     |
+| Set Windows                   | ✖   | ✔                 | ✖   | ✖       | ✖           | ✖           | ✖     |       | ✖      | ✖     |
+| Start / Stop Hazard Lights    | ✖   | ✔                 | ✖   | ✖       | ✖           | ✖           | ✖     |       | ✖      | ✖     |
+| Start / Stop Hazard + Horn    | ✖   | ✔                 | ✖   | ✖       | ✖           | ✖           | ✖     | ✔     | ✖      | ✖     |
+| Schedule Charging and Climate | ✖   | ✔                 | ✖   | ✖       | ✖           | ✖           | ✖     |       | ✖      | ✖     |
+| Start / Stop Valet Mode       | ✖   | ✔                 | ✖   | ✖       | ✖           | ✖           | ✖     |       | ✖      | ✖     |
+| Set Navigation _(WIP)_        |     | ✔                 |     |         |             |             |       |       |        |       |
 
 ## Screenshots
 
@@ -161,6 +172,6 @@ These can be accessed via Developer Tools > Actions, or called from automations.
 
 If you receive an error while trying to login, please go through these steps:
 
-1. This integration supports USA, EU, China, India, Australia, New Zealand, Canada and Brazil. If you are outside these regions, you are welcome to create an issue and become a test user. USA and Brazil coverage is limited.
+1. This integration supports USA, EU, China, India, Australia, New Zealand, Canada, Brazil and Korea. If you are outside these regions, you are welcome to create an issue and become a test user. USA, Brazil and Korea coverage is limited.
 2. You can enable logging for this integration specifically and share your logs for investigation. To enable logging, click "Enable debug logging" on the integration. It can be accessed via **Settings → System → Logs**. See [Home Assistant troubleshooting: enabling debug logging](https://www.home-assistant.io/docs/configuration/troubleshooting/#enabling-debug-logging) for details.
 3. You can download a redacted diagnostics snapshot to attach to a bug report. Go to **Settings → Devices & Services → kia_uvo**, open the integration entry, click the menu (⋮) and select **Download diagnostics**. The dump is auto-redacted (tokens, device id, PIN, GPS coordinates, and reverse-geocoded addresses are removed) — safe to share. It contains the parsed vehicle state, API class, and version info, which helps diagnose field-mapping and region-specific issues.

--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ After installation, go to **Settings** → **Devices & Services** → **Integrat
 Choose **Korea** and **Hyundai** in the config flow. Home Assistant will show a MyHyundai authorization link. The registered OAuth callback forwards desktop browsers immediately, so capture it with the browser network log:
 
 1. Open the browser developer tools and select **Network**.
-2. Enable **Preserve log**, then open the authorization link and sign in with Pleos.
-3. After the browser reaches the Hyundai website, filter the requests for `oneapp.hyundai.com/redirect`.
-4. Copy that request's complete URL and paste it into Home Assistant with your vehicle-control PIN.
+2. Enable **Preserve log**, then open the authorization link.
+3. On the Hyundai login page, turn on the **Pleos account login** (`Pleos 계정 로그인`) switch at the bottom before entering your Pleos credentials.
+4. After the browser reaches the Hyundai website, filter the requests for `oneapp.hyundai.com/redirect`.
+5. Copy that request's complete URL and paste it into Home Assistant with your vehicle-control PIN.
 
 Home Assistant stores the renewable token set in the config entry. It does not store the MyHyundai account password. The integration saves rotated refresh credentials after each token refresh. Browser login is only required again if Hyundai expires or revokes those credentials.
 

--- a/custom_components/kia_uvo/binary_sensor.py
+++ b/custom_components/kia_uvo/binary_sensor.py
@@ -25,6 +25,16 @@ from .entity import HyundaiKiaConnectEntity
 _LOGGER = logging.getLogger(__name__)
 
 
+def _seat_heater_is_on(vehicle: Vehicle, attribute: str) -> bool:
+    """Return whether a seat status represents active heating."""
+    return getattr(vehicle, attribute, None) in {
+        "On",
+        "Low Heat",
+        "Medium Heat",
+        "High Heat",
+    }
+
+
 @dataclass(frozen=True, kw_only=True)
 class HyundaiKiaBinarySensorEntityDescription(BinarySensorEntityDescription):
     """A class that describes custom binary sensor entities."""
@@ -440,7 +450,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
     HyundaiKiaBinarySensorEntityDescription(
         key="front_left_seat_heater_on",
         translation_key="front_left_seat_heater_on",
-        is_on=lambda vehicle: vehicle.front_left_seat_status,
+        is_on=lambda vehicle: _seat_heater_is_on(vehicle, "front_left_seat_status"),
         on_icon="mdi:seat-heater",
         off_icon="mdi:seat-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -448,7 +458,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
     HyundaiKiaBinarySensorEntityDescription(
         key="front_right_seat_heater_on",
         translation_key="front_right_seat_heater_on",
-        is_on=lambda vehicle: vehicle.front_right_seat_status,
+        is_on=lambda vehicle: _seat_heater_is_on(vehicle, "front_right_seat_status"),
         on_icon="mdi:seat-heater",
         off_icon="mdi:seat-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -456,7 +466,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
     HyundaiKiaBinarySensorEntityDescription(
         key="rear_left_seat_heater_on",
         translation_key="rear_left_seat_heater_on",
-        is_on=lambda vehicle: vehicle.rear_left_seat_status,
+        is_on=lambda vehicle: _seat_heater_is_on(vehicle, "rear_left_seat_status"),
         on_icon="mdi:seat-heater",
         off_icon="mdi:seat-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -464,7 +474,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
     HyundaiKiaBinarySensorEntityDescription(
         key="rear_right_seat_heater_on",
         translation_key="rear_right_seat_heater_on",
-        is_on=lambda vehicle: vehicle.rear_right_seat_status,
+        is_on=lambda vehicle: _seat_heater_is_on(vehicle, "rear_right_seat_status"),
         on_icon="mdi:seat-heater",
         off_icon="mdi:seat-outline",
         entity_category=EntityCategory.DIAGNOSTIC,

--- a/custom_components/kia_uvo/binary_sensor.py
+++ b/custom_components/kia_uvo/binary_sensor.py
@@ -25,9 +25,9 @@ from .entity import HyundaiKiaConnectEntity
 _LOGGER = logging.getLogger(__name__)
 
 
-def _seat_heater_is_on(vehicle: Vehicle, attribute: str) -> bool:
+def _seat_heater_is_on(status: str | None) -> bool:
     """Return whether a seat status represents active heating."""
-    return getattr(vehicle, attribute, None) in {
+    return status in {
         "On",
         "Low Heat",
         "Medium Heat",
@@ -450,7 +450,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
     HyundaiKiaBinarySensorEntityDescription(
         key="front_left_seat_heater_on",
         translation_key="front_left_seat_heater_on",
-        is_on=lambda vehicle: _seat_heater_is_on(vehicle, "front_left_seat_status"),
+        is_on=lambda vehicle: _seat_heater_is_on(vehicle.front_left_seat_status),
         on_icon="mdi:seat-heater",
         off_icon="mdi:seat-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -458,7 +458,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
     HyundaiKiaBinarySensorEntityDescription(
         key="front_right_seat_heater_on",
         translation_key="front_right_seat_heater_on",
-        is_on=lambda vehicle: _seat_heater_is_on(vehicle, "front_right_seat_status"),
+        is_on=lambda vehicle: _seat_heater_is_on(vehicle.front_right_seat_status),
         on_icon="mdi:seat-heater",
         off_icon="mdi:seat-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -466,7 +466,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
     HyundaiKiaBinarySensorEntityDescription(
         key="rear_left_seat_heater_on",
         translation_key="rear_left_seat_heater_on",
-        is_on=lambda vehicle: _seat_heater_is_on(vehicle, "rear_left_seat_status"),
+        is_on=lambda vehicle: _seat_heater_is_on(vehicle.rear_left_seat_status),
         on_icon="mdi:seat-heater",
         off_icon="mdi:seat-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -474,7 +474,7 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaBinarySensorEntityDescription, ...]] 
     HyundaiKiaBinarySensorEntityDescription(
         key="rear_right_seat_heater_on",
         translation_key="rear_right_seat_heater_on",
-        is_on=lambda vehicle: _seat_heater_is_on(vehicle, "rear_right_seat_status"),
+        is_on=lambda vehicle: _seat_heater_is_on(vehicle.rear_right_seat_status),
         on_icon="mdi:seat-heater",
         off_icon="mdi:seat-outline",
         entity_category=EntityCategory.DIAGNOSTIC,

--- a/custom_components/kia_uvo/config_flow.py
+++ b/custom_components/kia_uvo/config_flow.py
@@ -237,15 +237,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         assert self._region_data is not None
         errors: dict[str, str] = {}
         pin = user_input.get(CONF_PIN, DEFAULT_PIN) if user_input else DEFAULT_PIN
-        vehicle_manager = VehicleManager(
-            region=self._region_data[CONF_REGION],
-            brand=self._region_data[CONF_BRAND],
-            language=self.hass.config.language,
-            username="",
-            password="",
-            pin=pin,
-        )
-        self._vehicle_manager = vehicle_manager
+        vehicle_manager = self._create_browser_vehicle_manager(pin)
 
         if user_input is not None:
             try:
@@ -259,37 +251,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception during MyHyundai login")
                 errors["base"] = "unknown"
             else:
-                token = vehicle_manager.token
-                full_config = {
-                    **self._region_data,
-                    CONF_USERNAME: "",
-                    CONF_PASSWORD: "",
-                    CONF_PIN: pin,
-                    CONF_TOKEN: token.to_persistent_dict(),
-                }
-                if self._is_reconfigure:
-                    return self.async_update_reload_and_abort(
-                        self._get_reconfigure_entry(),
-                        data_updates=full_config,
-                    )
-                if self.reauth_entry is not None:
-                    self.hass.config_entries.async_update_entry(
-                        self.reauth_entry, data=full_config
-                    )
-                    await self.hass.config_entries.async_reload(
-                        self.reauth_entry.entry_id
-                    )
-                    return self.async_abort(reason="reauth_successful")
-
-                account_id = token.user_id or token.cc_id
-                if not account_id and vehicle_manager.vehicles:
-                    account_id = next(iter(vehicle_manager.vehicles))
-                title = f"{BRAND_HYUNDAI} {REGION_KOREA}"
-                await self.async_set_unique_id(
-                    hashlib.sha256(f"{title} {account_id or ''}".encode()).hexdigest()
-                )
-                self._abort_if_unique_id_configured()
-                return self.async_create_entry(title=title, data=full_config)
+                return await self._async_finish_browser_login(vehicle_manager, pin)
 
         authorization_url = vehicle_manager.get_authorization_url()
         return self.async_show_form(
@@ -298,6 +260,65 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
             description_placeholders={"authorization_url": authorization_url},
         )
+
+    def _create_browser_vehicle_manager(self, pin: str) -> VehicleManager:
+        """Create the manager used by the Korea browser-login step."""
+        assert self._region_data is not None
+        vehicle_manager = VehicleManager(
+            region=self._region_data[CONF_REGION],
+            brand=self._region_data[CONF_BRAND],
+            language=self.hass.config.language,
+            username="",
+            password="",
+            pin=pin,
+        )
+        self._vehicle_manager = vehicle_manager
+        return vehicle_manager
+
+    async def _async_finish_browser_login(
+        self, vehicle_manager: VehicleManager, pin: str
+    ) -> ConfigFlowResult:
+        """Store a completed Korea browser login in the active config flow."""
+        assert self._region_data is not None
+        token = vehicle_manager.token
+        full_config = {
+            **self._region_data,
+            CONF_USERNAME: "",
+            CONF_PASSWORD: "",
+            CONF_PIN: pin,
+            CONF_TOKEN: token.to_persistent_dict(),
+        }
+        if self._is_reconfigure:
+            return self.async_update_reload_and_abort(
+                self._get_reconfigure_entry(),
+                data_updates=full_config,
+            )
+        if self.reauth_entry is not None:
+            self.hass.config_entries.async_update_entry(
+                self.reauth_entry, data=full_config
+            )
+            await self.hass.config_entries.async_reload(self.reauth_entry.entry_id)
+            return self.async_abort(reason="reauth_successful")
+
+        account_id = token.user_id or token.cc_id
+        if not account_id and vehicle_manager.vehicles:
+            account_id = next(iter(vehicle_manager.vehicles))
+        title = f"{BRAND_HYUNDAI} {REGION_KOREA}"
+        await self.async_set_unique_id(
+            hashlib.sha256(f"{title} {account_id or ''}".encode()).hexdigest()
+        )
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(title=title, data=full_config)
+
+    async def _async_step_korea_browser_for_entry(
+        self, entry: ConfigEntry
+    ) -> ConfigFlowResult:
+        """Start Korea browser authentication using an existing entry."""
+        self._region_data = {
+            CONF_REGION: entry.data[CONF_REGION],
+            CONF_BRAND: entry.data[CONF_BRAND],
+        }
+        return await self.async_step_credentials_browser()
 
     async def async_step_credentials_password(
         self, user_input: dict[str, Any] | None = None
@@ -496,11 +517,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._is_reconfigure = True
                 entry = self._get_reconfigure_entry()
                 if REGIONS[entry.data[CONF_REGION]] == REGION_KOREA:
-                    self._region_data = {
-                        CONF_REGION: entry.data[CONF_REGION],
-                        CONF_BRAND: entry.data[CONF_BRAND],
-                    }
-                    return await self.async_step_credentials_browser()
+                    return await self._async_step_korea_browser_for_entry(entry)
                 return await self.async_step_user()
             else:
                 return await self.async_step_reconfigure_pin()
@@ -554,11 +571,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.reauth_entry is not None
             and REGIONS[self.reauth_entry.data[CONF_REGION]] == REGION_KOREA
         ):
-            self._region_data = {
-                CONF_REGION: self.reauth_entry.data[CONF_REGION],
-                CONF_BRAND: self.reauth_entry.data[CONF_BRAND],
-            }
-            return await self.async_step_credentials_browser()
+            return await self._async_step_korea_browser_for_entry(self.reauth_entry)
         return await self.async_step_user()
 
 

--- a/custom_components/kia_uvo/config_flow.py
+++ b/custom_components/kia_uvo/config_flow.py
@@ -25,12 +25,14 @@ from hyundai_kia_connect_api.const import OTP_NOTIFY_TYPE
 from hyundai_kia_connect_api.exceptions import AuthenticationError
 
 from .const import (
+    BRAND_HYUNDAI,
     BRANDS,
     CONF_BRAND,
     CONF_ENABLE_GEOLOCATION_ENTITY,
     CONF_FORCE_REFRESH_INTERVAL,
     CONF_NO_FORCE_REFRESH_HOUR_FINISH,
     CONF_NO_FORCE_REFRESH_HOUR_START,
+    CONF_OAUTH_REDIRECT_URL,
     CONF_TOKEN,
     CONF_USE_EMAIL_WITH_GEOCODE_API,
     DEFAULT_ENABLE_GEOLOCATION_ENTITY,
@@ -41,6 +43,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_USE_EMAIL_WITH_GEOCODE_API,
     DOMAIN,
+    REGION_KOREA,
     REGIONS,
 )
 
@@ -98,6 +101,15 @@ STEP_CREDENTIALS_DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_USERNAME): str,
         vol.Required(CONF_PASSWORD): str,
         vol.Optional(CONF_PIN, default=DEFAULT_PIN): str,
+    }
+)
+
+STEP_KOREA_BROWSER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_OAUTH_REDIRECT_URL): str,
+        vol.Optional(CONF_PIN, default=DEFAULT_PIN): selector(
+            {"text": {"type": "password"}}
+        ),
     }
 )
 
@@ -202,6 +214,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._region_data = user_input
         self._region_data[CONF_REGION] = int(self._region_data[CONF_REGION])
         self._region_data[CONF_BRAND] = int(self._region_data[CONF_BRAND])
+        if REGIONS[self._region_data[CONF_REGION]] == REGION_KOREA:
+            if BRANDS[self._region_data[CONF_BRAND]] != BRAND_HYUNDAI:
+                return self.async_show_form(
+                    step_id="user",
+                    data_schema=STEP_REGION_DATA_SCHEMA,
+                    errors={"base": "unsupported_region_brand"},
+                )
+            return await self.async_step_credentials_browser()
         # Unused but keeping the code since I suspect token based will be back!
         # if REGIONS[self._region_data[CONF_REGION]] == REGION_EUROPE and (
         #    BRANDS[self._region_data[CONF_BRAND]] == BRAND_KIA
@@ -209,6 +229,75 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # ):
         #    return await self.async_step_credentials_token()
         return await self.async_step_credentials_password()
+
+    async def async_step_credentials_browser(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Authenticate a Korean MyHyundai account through Pleos OAuth."""
+        assert self._region_data is not None
+        errors: dict[str, str] = {}
+        pin = user_input.get(CONF_PIN, DEFAULT_PIN) if user_input else DEFAULT_PIN
+        vehicle_manager = VehicleManager(
+            region=self._region_data[CONF_REGION],
+            brand=self._region_data[CONF_BRAND],
+            language=self.hass.config.language,
+            username="",
+            password="",
+            pin=pin,
+        )
+        self._vehicle_manager = vehicle_manager
+
+        if user_input is not None:
+            try:
+                await self.hass.async_add_executor_job(
+                    vehicle_manager.login_with_redirect_url,
+                    user_input[CONF_OAUTH_REDIRECT_URL].strip(),
+                )
+            except AuthenticationError:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception during MyHyundai login")
+                errors["base"] = "unknown"
+            else:
+                token = vehicle_manager.token
+                full_config = {
+                    **self._region_data,
+                    CONF_USERNAME: "",
+                    CONF_PASSWORD: "",
+                    CONF_PIN: pin,
+                    CONF_TOKEN: token.to_persistent_dict(),
+                }
+                if self._is_reconfigure:
+                    return self.async_update_reload_and_abort(
+                        self._get_reconfigure_entry(),
+                        data_updates=full_config,
+                    )
+                if self.reauth_entry is not None:
+                    self.hass.config_entries.async_update_entry(
+                        self.reauth_entry, data=full_config
+                    )
+                    await self.hass.config_entries.async_reload(
+                        self.reauth_entry.entry_id
+                    )
+                    return self.async_abort(reason="reauth_successful")
+
+                account_id = token.user_id or token.cc_id
+                if not account_id and vehicle_manager.vehicles:
+                    account_id = next(iter(vehicle_manager.vehicles))
+                title = f"{BRAND_HYUNDAI} {REGION_KOREA}"
+                await self.async_set_unique_id(
+                    hashlib.sha256(f"{title} {account_id or ''}".encode()).hexdigest()
+                )
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(title=title, data=full_config)
+
+        authorization_url = vehicle_manager.get_authorization_url()
+        return self.async_show_form(
+            step_id="credentials_browser",
+            data_schema=STEP_KOREA_BROWSER_DATA_SCHEMA,
+            errors=errors,
+            description_placeholders={"authorization_url": authorization_url},
+        )
 
     async def async_step_credentials_password(
         self, user_input: dict[str, Any] | None = None
@@ -405,6 +494,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             if user_input["reconfigure_choice"] == "reauth":
                 self._is_reconfigure = True
+                entry = self._get_reconfigure_entry()
+                if REGIONS[entry.data[CONF_REGION]] == REGION_KOREA:
+                    self._region_data = {
+                        CONF_REGION: entry.data[CONF_REGION],
+                        CONF_BRAND: entry.data[CONF_BRAND],
+                    }
+                    return await self.async_step_credentials_browser()
                 return await self.async_step_user()
             else:
                 return await self.async_step_reconfigure_pin()
@@ -454,7 +550,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 step_id="reauth_confirm",
                 data_schema=vol.Schema({}),
             )
-        self._reauth_config = True
+        if (
+            self.reauth_entry is not None
+            and REGIONS[self.reauth_entry.data[CONF_REGION]] == REGION_KOREA
+        ):
+            self._region_data = {
+                CONF_REGION: self.reauth_entry.data[CONF_REGION],
+                CONF_BRAND: self.reauth_entry.data[CONF_BRAND],
+            }
+            return await self.async_step_credentials_browser()
         return await self.async_step_user()
 
 

--- a/custom_components/kia_uvo/const.py
+++ b/custom_components/kia_uvo/const.py
@@ -11,6 +11,7 @@ CONF_NO_FORCE_REFRESH_HOUR_FINISH: str = "no_force_refresh_hour_finish"
 CONF_ENABLE_GEOLOCATION_ENTITY: str = "enable_geolocation_entity"
 CONF_USE_EMAIL_WITH_GEOCODE_API: str = "use_email_with_geocode_api"
 CONF_TOKEN: str = "token"
+CONF_OAUTH_REDIRECT_URL: str = "oauth_redirect_url"
 
 REGION_EUROPE: str = "Europe"
 REGION_CANADA: str = "Canada"
@@ -20,6 +21,7 @@ REGION_AUSTRALIA: str = "Australia"
 REGION_INDIA: str = "India"
 REGION_NZ: str = "New Zealand"
 REGION_BRAZIL: str = "Brazil"
+REGION_KOREA: str = "Korea"
 REGIONS = {
     1: REGION_EUROPE,
     2: REGION_CANADA,
@@ -29,6 +31,7 @@ REGIONS = {
     6: REGION_INDIA,
     7: REGION_NZ,
     8: REGION_BRAZIL,
+    10: REGION_KOREA,
 }
 BRAND_KIA: str = "Kia"
 BRAND_HYUNDAI: str = "Hyundai"

--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -8,7 +8,7 @@ import logging
 import traceback
 from collections.abc import Callable
 from datetime import timedelta
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -58,6 +58,22 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
+def _token_from_config(
+    token_data: dict[str, Any] | None, pin: str | None
+) -> Token | None:
+    """Restore renewable credentials and add the separately stored PIN."""
+    if not token_data:
+        return None
+    token = Token.from_dict(token_data)
+    token.pin = pin
+    return token
+
+
+def _token_for_config(token: Token) -> dict[str, Any]:
+    """Serialize renewable credentials without transient control secrets."""
+    return cast(dict[str, Any], token.to_persistent_dict())
+
+
 class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Class to manage fetching data from the API."""
 
@@ -66,12 +82,16 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any
         self.platforms: set[str] = set()
         self._action_lock = asyncio.Lock()
 
+        pin = config_entry.data.get(CONF_PIN)
+        token_data = config_entry.data.get(CONF_TOKEN)
+        token = _token_from_config(token_data, pin)
+
         self.vehicle_manager = VehicleManager(
             region=config_entry.data.get(CONF_REGION),
             brand=config_entry.data.get(CONF_BRAND),
             username=config_entry.data.get(CONF_USERNAME),
             password=config_entry.data.get(CONF_PASSWORD),
-            pin=config_entry.data.get(CONF_PIN),
+            pin=pin,
             geocode_api_enable=config_entry.options.get(
                 CONF_ENABLE_GEOLOCATION_ENTITY, DEFAULT_ENABLE_GEOLOCATION_ENTITY
             ),
@@ -79,9 +99,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any
                 CONF_USE_EMAIL_WITH_GEOCODE_API, DEFAULT_USE_EMAIL_WITH_GEOCODE_API
             ),
             language=hass.config.language,
-            token=Token.from_dict(config_entry.data.get(CONF_TOKEN, None))
-            if config_entry.data.get(CONF_TOKEN, None)
-            else None,
+            token=token,
         )
         self.scan_interval: int = (
             config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL) * 60
@@ -622,7 +640,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any
         """Persist the latest token into the config entry."""
         config_entry = self.config_entry
         assert config_entry is not None
-        new_token = self.vehicle_manager.token.to_dict()
+        new_token = _token_for_config(self.vehicle_manager.token)
         # Only update if token actually changed
         if new_token and new_token != config_entry.data.get(CONF_TOKEN):
             updated_data = {**config_entry.data, CONF_TOKEN: new_token}

--- a/custom_components/kia_uvo/coordinator.py
+++ b/custom_components/kia_uvo/coordinator.py
@@ -8,7 +8,7 @@ import logging
 import traceback
 from collections.abc import Callable
 from datetime import timedelta
-from typing import Any, cast
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -67,11 +67,6 @@ def _token_from_config(
     token = Token.from_dict(token_data)
     token.pin = pin
     return token
-
-
-def _token_for_config(token: Token) -> dict[str, Any]:
-    """Serialize renewable credentials without transient control secrets."""
-    return cast(dict[str, Any], token.to_persistent_dict())
 
 
 class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
@@ -640,7 +635,7 @@ class HyundaiKiaConnectDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any
         """Persist the latest token into the config entry."""
         config_entry = self.config_entry
         assert config_entry is not None
-        new_token = _token_for_config(self.vehicle_manager.token)
+        new_token = self.vehicle_manager.token.to_persistent_dict()
         # Only update if token actually changed
         if new_token and new_token != config_entry.data.get(CONF_TOKEN):
             updated_data = {**config_entry.data, CONF_TOKEN: new_token}

--- a/custom_components/kia_uvo/services.py
+++ b/custom_components/kia_uvo/services.py
@@ -15,7 +15,7 @@ from hyundai_kia_connect_api import (
     WindowRequestOptions,
 )
 
-from .const import DOMAIN, OffPeakChargingMode
+from .const import DOMAIN, REGION_KOREA, REGIONS, OffPeakChargingMode
 from .coordinator import HyundaiKiaConnectDataUpdateCoordinator
 
 SERVICE_UPDATE = "update"
@@ -65,6 +65,16 @@ SUPPORTED_SERVICES = (
 _LOGGER = logging.getLogger(__name__)
 
 
+def _seat_climate_state(value: Any, region: int) -> int | None:
+    """Convert a service seat value to the region's API representation."""
+    if value is None:
+        return None
+    state = int(value)
+    if REGIONS[region] == REGION_KOREA and state == 0:
+        return 2
+    return state
+
+
 @callback
 def async_setup_services(hass: HomeAssistant) -> bool:
     """Set up services for Hyundai Kia Connect"""
@@ -95,14 +105,11 @@ def async_setup_services(hass: HomeAssistant) -> bool:
         # Confirm values are correct datatype
         if heating is not None:
             heating = int(heating)
-        if front_left_seat is not None:
-            front_left_seat = int(front_left_seat)
-        if front_right_seat is not None:
-            front_right_seat = int(front_right_seat)
-        if rear_left_seat is not None:
-            rear_left_seat = int(rear_left_seat)
-        if rear_right_seat is not None:
-            rear_right_seat = int(rear_right_seat)
+        region = coordinator.vehicle_manager.region
+        front_left_seat = _seat_climate_state(front_left_seat, region)
+        front_right_seat = _seat_climate_state(front_right_seat, region)
+        rear_left_seat = _seat_climate_state(rear_left_seat, region)
+        rear_right_seat = _seat_climate_state(rear_right_seat, region)
         if steering_wheel is not None:
             steering_wheel = int(steering_wheel)
 

--- a/custom_components/kia_uvo/strings.json
+++ b/custom_components/kia_uvo/strings.json
@@ -22,7 +22,7 @@
       },
       "credentials_browser": {
         "title": "MyHyundai Korea sign-in",
-        "description": "Open [MyHyundai sign-in]({authorization_url}) in a new browser tab. Before signing in, open the browser developer tools, select Network, and enable Preserve log. After login reaches the Hyundai website, filter the requests for `oneapp.hyundai.com/redirect`, copy that request's complete URL, and paste it below. Home Assistant stores renewable tokens, not your account password.",
+        "description": "Open [MyHyundai sign-in]({authorization_url}) in a new browser tab. On the Hyundai login page, turn on the `Pleos account login` (`Pleos 계정 로그인`) switch at the bottom before entering your Pleos credentials. Before signing in, open the browser developer tools, select Network, and enable Preserve log. After login reaches the Hyundai website, filter the requests for `oneapp.hyundai.com/redirect`, copy that request's complete URL, and paste it below. Home Assistant stores renewable tokens, not your account password.",
         "data": {
           "oauth_redirect_url": "Complete oneapp.hyundai.com redirect request URL",
           "pin": "PIN"

--- a/custom_components/kia_uvo/strings.json
+++ b/custom_components/kia_uvo/strings.json
@@ -20,6 +20,14 @@
           "pin": "[%key:common::config_flow::data::pin%]"
         }
       },
+      "credentials_browser": {
+        "title": "MyHyundai Korea sign-in",
+        "description": "Open [MyHyundai sign-in]({authorization_url}) in a new browser tab. Before signing in, open the browser developer tools, select Network, and enable Preserve log. After login reaches the Hyundai website, filter the requests for `oneapp.hyundai.com/redirect`, copy that request's complete URL, and paste it below. Home Assistant stores renewable tokens, not your account password.",
+        "data": {
+          "oauth_redirect_url": "Complete oneapp.hyundai.com redirect request URL",
+          "pin": "PIN"
+        }
+      },
       "user": {
         "title": "[%key:component::hyundai_kia_connect::config::step::user::title%]",
         "description": "[%key:component::hyundai_kia_connect::config::step::user::description%]",
@@ -68,6 +76,7 @@
     "error": {
       "invalid_auth": "[%key:component::hyundai_kia_connect::config::error::invalid_auth%]",
       "invalid_credentials": "[%key:component::hyundai_kia_connect::config::error::invalid_credentials%]",
+      "unsupported_region_brand": "MyHyundai Korea currently supports Hyundai vehicles only.",
       "unknown": "[%key:component::hyundai_kia_connect::config::error::unknown%]"
     }
   },

--- a/custom_components/kia_uvo/translations/en.json
+++ b/custom_components/kia_uvo/translations/en.json
@@ -20,6 +20,14 @@
           "pin": "Pin"
         }
       },
+      "credentials_browser": {
+        "title": "MyHyundai Korea sign-in",
+        "description": "Open [MyHyundai sign-in]({authorization_url}) in a new browser tab. Before signing in, open the browser developer tools, select Network, and enable Preserve log. After login reaches the Hyundai website, filter the requests for `oneapp.hyundai.com/redirect`, copy that request's complete URL, and paste it below. Home Assistant stores renewable tokens, not your account password.",
+        "data": {
+          "oauth_redirect_url": "Complete oneapp.hyundai.com redirect request URL",
+          "pin": "PIN"
+        }
+      },
       "user": {
         "title": "Hyundai / Kia Connect - Region and Brand",
         "description": "Set up your Hyundai (Bluelink) / Kia (Uvo) Connect to integrate with Home Assistant.",
@@ -68,6 +76,7 @@
     "error": {
       "invalid_auth": "Login failed into Hyundai (Bluelink) / Kia (Uvo) Connect servers. Please use the official app to logout and log back in, then try again.",
       "invalid_credentials": "Invalid username or password",
+      "unsupported_region_brand": "MyHyundai Korea currently supports Hyundai vehicles only.",
       "unknown": "Unexpected error"
     }
   },

--- a/custom_components/kia_uvo/translations/en.json
+++ b/custom_components/kia_uvo/translations/en.json
@@ -22,7 +22,7 @@
       },
       "credentials_browser": {
         "title": "MyHyundai Korea sign-in",
-        "description": "Open [MyHyundai sign-in]({authorization_url}) in a new browser tab. Before signing in, open the browser developer tools, select Network, and enable Preserve log. After login reaches the Hyundai website, filter the requests for `oneapp.hyundai.com/redirect`, copy that request's complete URL, and paste it below. Home Assistant stores renewable tokens, not your account password.",
+        "description": "Open [MyHyundai sign-in]({authorization_url}) in a new browser tab. On the Hyundai login page, turn on the `Pleos account login` (`Pleos 계정 로그인`) switch at the bottom before entering your Pleos credentials. Before signing in, open the browser developer tools, select Network, and enable Preserve log. After login reaches the Hyundai website, filter the requests for `oneapp.hyundai.com/redirect`, copy that request's complete URL, and paste it below. Home Assistant stores renewable tokens, not your account password.",
         "data": {
           "oauth_redirect_url": "Complete oneapp.hyundai.com redirect request URL",
           "pin": "PIN"

--- a/tests/test_korea_config_flow.py
+++ b/tests/test_korea_config_flow.py
@@ -1,0 +1,215 @@
+"""Tests for the MyHyundai Korea browser-login flow."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.const import CONF_PASSWORD, CONF_PIN, CONF_REGION, CONF_USERNAME
+from hyundai_kia_connect_api import Token
+from hyundai_kia_connect_api.exceptions import AuthenticationError
+
+from custom_components.kia_uvo.binary_sensor import _seat_heater_is_on
+from custom_components.kia_uvo.config_flow import ConfigFlow
+from custom_components.kia_uvo.const import (
+    CONF_BRAND,
+    CONF_OAUTH_REDIRECT_URL,
+    CONF_TOKEN,
+    REGIONS,
+)
+from custom_components.kia_uvo.coordinator import _token_for_config, _token_from_config
+from custom_components.kia_uvo.services import _seat_climate_state
+
+
+class FakeHass:
+    """Small Home Assistant stub for executor-backed config-flow calls."""
+
+    def __init__(self) -> None:
+        self.config = SimpleNamespace(language="en")
+        self.config_entries = MagicMock()
+
+    async def async_add_executor_job(self, target, *args):
+        """Run the blocking function inline for a deterministic test."""
+        return target(*args)
+
+
+class FakeVehicleManager:
+    """VehicleManager stub that returns a renewable token set."""
+
+    def __init__(self, **kwargs) -> None:
+        self.init_args = kwargs
+        self.token = Token(
+            username="person@example.com",
+            password="account-password",
+            access_token="Bearer ccs-token",
+            refresh_token="refresh-token",
+            pin=kwargs["pin"],
+            control_token="control-token",
+            control_token_expiry=123,
+            user_id="account-id",
+        )
+        self.vehicles = {"vehicle-id": MagicMock()}
+        self.redirect_url: str | None = None
+
+    def get_authorization_url(self) -> str:
+        return "https://idpconnect-kr.hyundai.com/authorize"
+
+    def login_with_redirect_url(self, redirect_url: str) -> bool:
+        self.redirect_url = redirect_url
+        return True
+
+
+def _flow() -> ConfigFlow:
+    flow = ConfigFlow()
+    flow.hass = FakeHass()
+    return flow
+
+
+@pytest.mark.asyncio
+async def test_korea_hyundai_routes_to_browser_login() -> None:
+    flow = _flow()
+
+    with patch(
+        "custom_components.kia_uvo.config_flow.VehicleManager", FakeVehicleManager
+    ):
+        result = await flow.async_step_user({CONF_REGION: "10", CONF_BRAND: "2"})
+
+    assert REGIONS[10] == "Korea"
+    assert result["type"] == "form"
+    assert result["step_id"] == "credentials_browser"
+    assert result["description_placeholders"] == {
+        "authorization_url": "https://idpconnect-kr.hyundai.com/authorize"
+    }
+
+
+@pytest.mark.asyncio
+async def test_korea_rejects_non_hyundai_brand() -> None:
+    flow = _flow()
+
+    result = await flow.async_step_user({CONF_REGION: "10", CONF_BRAND: "1"})
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "unsupported_region_brand"}
+
+
+@pytest.mark.asyncio
+async def test_browser_login_stores_renewable_token_without_callback_or_secrets() -> (
+    None
+):
+    flow = _flow()
+    flow._region_data = {CONF_REGION: 10, CONF_BRAND: 2}
+    flow.async_set_unique_id = AsyncMock()
+    flow._abort_if_unique_id_configured = MagicMock()
+    callback = "https://oneapp.hyundai.com/redirect?code=one-time-code&state=hmgoneapp"
+
+    with patch(
+        "custom_components.kia_uvo.config_flow.VehicleManager", FakeVehicleManager
+    ):
+        result = await flow.async_step_credentials_browser(
+            {CONF_OAUTH_REDIRECT_URL: f"  {callback}  ", CONF_PIN: "1234"}
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "Hyundai Korea"
+    data = result["data"]
+    assert data[CONF_REGION] == 10
+    assert data[CONF_BRAND] == 2
+    assert data[CONF_USERNAME] == ""
+    assert data[CONF_PASSWORD] == ""
+    assert data[CONF_PIN] == "1234"
+    assert CONF_OAUTH_REDIRECT_URL not in data
+    assert data[CONF_TOKEN]["refresh_token"] == "refresh-token"
+    assert data[CONF_TOKEN]["password"] is None
+    assert data[CONF_TOKEN]["pin"] is None
+    assert data[CONF_TOKEN]["control_token"] is None
+
+
+@pytest.mark.asyncio
+async def test_browser_login_reports_invalid_callback() -> None:
+    class RejectingVehicleManager(FakeVehicleManager):
+        def login_with_redirect_url(self, redirect_url: str) -> bool:
+            raise AuthenticationError("invalid callback")
+
+    flow = _flow()
+    flow._region_data = {CONF_REGION: 10, CONF_BRAND: 2}
+
+    with patch(
+        "custom_components.kia_uvo.config_flow.VehicleManager",
+        RejectingVehicleManager,
+    ):
+        result = await flow.async_step_credentials_browser(
+            {CONF_OAUTH_REDIRECT_URL: "https://example.com", CONF_PIN: "1234"}
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "credentials_browser"
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+@pytest.mark.asyncio
+async def test_korea_reauth_returns_directly_to_browser_login() -> None:
+    flow = _flow()
+    entry = MagicMock(
+        entry_id="entry-id",
+        data={CONF_REGION: 10, CONF_BRAND: 2},
+    )
+    flow.context = {"entry_id": "entry-id"}
+    flow.hass.config_entries.async_get_entry.return_value = entry
+
+    confirm = await flow.async_step_reauth()
+    with patch(
+        "custom_components.kia_uvo.config_flow.VehicleManager", FakeVehicleManager
+    ):
+        browser = await flow.async_step_reauth_confirm({})
+
+    assert confirm["step_id"] == "reauth_confirm"
+    assert browser["step_id"] == "credentials_browser"
+    assert flow._region_data == {CONF_REGION: 10, CONF_BRAND: 2}
+
+
+def test_config_token_round_trip_injects_pin_only_at_runtime() -> None:
+    token = Token(
+        access_token="Bearer ccs-token",
+        refresh_token="refresh-token",
+        pin="1234",
+        control_token="short-lived-control-token",
+        control_token_expiry=123,
+    )
+
+    stored = _token_for_config(token)
+    restored = _token_from_config(stored, "5678")
+
+    assert stored["refresh_token"] == "refresh-token"
+    assert stored["pin"] is None
+    assert stored["control_token"] is None
+    assert restored is not None
+    assert restored.refresh_token == "refresh-token"
+    assert restored.pin == "5678"
+    assert restored.control_token is None
+
+
+def test_korea_seat_off_uses_gen2_off_state() -> None:
+    assert _seat_climate_state("0", 10) == 2
+    assert _seat_climate_state("6", 10) == 6
+    assert _seat_climate_state("0", 1) == 0
+    assert _seat_climate_state(None, 10) is None
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        ("Off", False),
+        ("Low Cool", False),
+        ("High Cool", False),
+        ("On", True),
+        ("Low Heat", True),
+        ("High Heat", True),
+    ],
+)
+def test_seat_heater_binary_sensor_uses_status_meaning(
+    status: str, expected: bool
+) -> None:
+    vehicle = MagicMock(front_left_seat_status=status)
+    assert _seat_heater_is_on(vehicle, "front_left_seat_status") is expected

--- a/tests/test_korea_config_flow.py
+++ b/tests/test_korea_config_flow.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -81,6 +83,16 @@ async def test_korea_hyundai_routes_to_browser_login() -> None:
     assert result["description_placeholders"] == {
         "authorization_url": "https://idpconnect-kr.hyundai.com/authorize"
     }
+
+
+def test_korea_login_instructions_select_pleos_account() -> None:
+    """Tell users how to switch away from the legacy Hyundai login form."""
+    strings_path = Path(__file__).parents[1] / "custom_components/kia_uvo/strings.json"
+    description = json.loads(strings_path.read_text())["config"]["step"][
+        "credentials_browser"
+    ]["description"]
+
+    assert "Pleos account login" in description
 
 
 @pytest.mark.asyncio

--- a/tests/test_korea_config_flow.py
+++ b/tests/test_korea_config_flow.py
@@ -20,7 +20,7 @@ from custom_components.kia_uvo.const import (
     CONF_TOKEN,
     REGIONS,
 )
-from custom_components.kia_uvo.coordinator import _token_for_config, _token_from_config
+from custom_components.kia_uvo.coordinator import _token_from_config
 from custom_components.kia_uvo.services import _seat_climate_state
 
 
@@ -190,7 +190,7 @@ def test_config_token_round_trip_injects_pin_only_at_runtime() -> None:
         control_token_expiry=123,
     )
 
-    stored = _token_for_config(token)
+    stored = token.to_persistent_dict()
     restored = _token_from_config(stored, "5678")
 
     assert stored["refresh_token"] == "refresh-token"
@@ -223,5 +223,4 @@ def test_korea_seat_off_uses_gen2_off_state() -> None:
 def test_seat_heater_binary_sensor_uses_status_meaning(
     status: str, expected: bool
 ) -> None:
-    vehicle = MagicMock(front_left_seat_status=status)
-    assert _seat_heater_is_on(vehicle, "front_left_seat_status") is expected
+    assert _seat_heater_is_on(status) is expected


### PR DESCRIPTION
## Summary

- add Hyundai Korea as a supported config-flow region
- authenticate MyHyundai Korea through the Pleos browser flow and a captured OAuth callback URL
- persist renewable credentials and save rotated refresh tokens without storing the account password or transient control token
- map the Korean GEN2 seat-off service value and make seat-heater binary sensors distinguish heating, ventilation, and off states
- document the login flow and currently validated Korean service coverage

## Dependency

This draft depends on Hyundai-Kia-Connect/hyundai_kia_connect_api#1309. The manifest intentionally remains pinned to the latest released API version, 4.29.1. It must be updated to the release containing API PR #1309 before this PR is ready to merge.

## Validation

- `pytest -q`: 85 passed
- Ruff check and format: passed
- Codespell, Prettier, JSON/YAML validation: passed
- installed through HACS on Home Assistant OS and configured with a Pleos redirect URL
- the entry survived a Home Assistant restart and restored its renewable session without the phone
- cached update, forced update, lock, unlock, and relock were exercised through Home Assistant
- Korean API-layer engine/climate, front-seat heating/ventilation, and heated-steering controls were validated on a real non-EV Hyundai
- the live-test build follows the API PR directly; EV controls remain unit-tested only because the available vehicle is not an EV

## Security

The pasted one-time callback URL is exchanged during setup and is not stored. The account password is never provided to Home Assistant. The vehicle-control PIN remains in the config entry, while short-lived control tokens are excluded from persistent token data.
