### PR TITLE
fix(sensor): allow unit conversion on charge duration sensors

### DIFF
--- a/custom_components/kia_uvo/sensor.py
+++ b/custom_components/kia_uvo/sensor.py
@@ -180,25 +180,33 @@ SENSOR_DESCRIPTIONS: Final[tuple[HyundaiKiaSensorEntityDescription, ...]] = (
         key="ev_estimated_current_charge_duration",
         translation_key="ev_estimated_current_charge_duration",
         icon="mdi:ev-station",
+        device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.MINUTES,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     HyundaiKiaSensorEntityDescription(
         key="ev_estimated_fast_charge_duration",
         translation_key="ev_estimated_fast_charge_duration",
         icon="mdi:ev-station",
+        device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.MINUTES,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     HyundaiKiaSensorEntityDescription(
         key="ev_estimated_portable_charge_duration",
         translation_key="ev_estimated_portable_charge_duration",
         icon="mdi:ev-station",
+        device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.MINUTES,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     HyundaiKiaSensorEntityDescription(
         key="ev_estimated_station_charge_duration",
         translation_key="ev_estimated_station_charge_duration",
         icon="mdi:ev-station",
+        device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.MINUTES,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     # Target charge range is transient — None at setup when the car is
     # asleep, telematics omits dte.rangeByFuel.totalAvailableRange, or


### PR DESCRIPTION
## Summary

The four EV estimated charge duration sensors are stuck displaying minutes: the "Unit of measurement" selector is absent from their entity settings, so a user who wants hours has to build a template sensor.

## Cause

The descriptions declared `native_unit_of_measurement=UnitOfTime.MINUTES` but no `device_class`. Unit conversion in Home Assistant is driven by the device class, not by the unit string — with no device class, the unit is opaque, no converter is selected, and the frontend offers no display unit to pick from.